### PR TITLE
Change default encryption for GeneratedPrivateKey Export

### DIFF
--- a/SshNet.Keygen/Extensions/PrivateKeyFileExtension.cs
+++ b/SshNet.Keygen/Extensions/PrivateKeyFileExtension.cs
@@ -34,7 +34,11 @@ namespace SshNet.Keygen.Extensions
 
         public static string ToOpenSshFormat(this IPrivateKeySource keyFile)
         {
-            return ((KeyHostAlgorithm) keyFile.HostKeyAlgorithms.First()).Key.ToOpenSshFormat(SshKeyGenerateInfo.DefaultSshKeyEncryption);
+            var encryption = SshKeyGenerateInfo.DefaultSshKeyEncryption;
+            if (keyFile is GeneratedPrivateKey generatedPrivateKey)
+                encryption = generatedPrivateKey.Info.Encryption;
+
+            return ((KeyHostAlgorithm) keyFile.HostKeyAlgorithms.First()).Key.ToOpenSshFormat(encryption);
         }
 
         public static string ToOpenSshFormat(this IPrivateKeySource keyFile, ISshKeyEncryption encryption)
@@ -48,7 +52,11 @@ namespace SshNet.Keygen.Extensions
 
         public static string ToPuttyFormat(this IPrivateKeySource keyFile)
         {
-            return ((KeyHostAlgorithm) keyFile.HostKeyAlgorithms.First()).Key.ToPuttyFormat(SshKeyGenerateInfo.DefaultSshKeyEncryption);
+            var encryption = SshKeyGenerateInfo.DefaultSshKeyEncryption;
+            if (keyFile is GeneratedPrivateKey generatedPrivateKey)
+                encryption = generatedPrivateKey.Info.Encryption;
+
+            return ((KeyHostAlgorithm) keyFile.HostKeyAlgorithms.First()).Key.ToPuttyFormat(encryption);
         }
 
         public static string ToPuttyFormat(this IPrivateKeySource keyFile, ISshKeyEncryption encryption)

--- a/SshNet.Keygen/GeneratedPrivateKey.cs
+++ b/SshNet.Keygen/GeneratedPrivateKey.cs
@@ -14,9 +14,13 @@ namespace SshNet.Keygen
 
         public Key Key { get; }
 
-        public GeneratedPrivateKey(Key key)
+        public SshKeyGenerateInfo Info { get; }
+
+        public GeneratedPrivateKey(Key key, SshKeyGenerateInfo info)
         {
             Key = key;
+            Info = info;
+
             _hostAlgorithms.Add(new KeyHostAlgorithm(key.ToString(), key));
 
             if (Key is not RsaKey rsaKey)

--- a/SshNet.Keygen/SshKey.cs
+++ b/SshNet.Keygen/SshKey.cs
@@ -119,7 +119,7 @@ namespace SshNet.Keygen
             }
 
             key.Comment = info.Comment;
-            return new GeneratedPrivateKey(key);
+            return new GeneratedPrivateKey(key, info);
         }
 
         private static RSA CreateRSA(int keySize)


### PR DESCRIPTION
If we want to get the string of the GeneratedPrivateKey use the Encryption from the GenerateInfo.