### PR TITLE
Add Dependabot config for NuGet and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      # one PR for all compatible minor/patch bumps, majors stay separate
+      nuget-minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
Adds `.github/dependabot.yml` so NuGet and GitHub Actions dependencies get weekly update PRs.

- NuGet: compatible minor/patch bumps grouped into one PR; majors stay separate.
- GitHub Actions: all action bumps grouped into one PR.

Mirrors the Dependabot config already in SshNet.Agent.