### PR TITLE
Bump GitHub Actions in the CI workflows

### DIFF
--- a/.github/workflows/dotnet-ubuntu.yml
+++ b/.github/workflows/dotnet-ubuntu.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 8.0.x
     - name: Restore dependencies
@@ -25,7 +25,7 @@ jobs:
       run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v5
       with:
         name: Sample-ubuntu
         path: |

--- a/.github/workflows/dotnet-windows.yml
+++ b/.github/workflows/dotnet-windows.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 8.0.x
     - name: Restore dependencies
@@ -25,7 +25,7 @@ jobs:
       run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v5
       with:
         name: sample-windows
         path: |


### PR DESCRIPTION
Updates the actions in the two test workflows off deprecated runners:

- `actions/checkout` v2 → v5
- `actions/setup-dotnet` v1 → v5
- `actions/upload-artifact` v4 → v5

Applies to `dotnet-ubuntu.yml` and `dotnet-windows.yml`. `submodules: recursive` is preserved for the Chaos.NaCl checkout.