### PR TITLE
Publish to NuGet via trusted publishing

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -9,12 +9,18 @@ jobs:
 
     runs-on: windows-latest
 
+    permissions:
+      # for the OIDC token behind NuGet trusted publishing
+      id-token: write
+      # the publish action pushes the version tag
+      contents: write
+
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 8.0.x
     - name: Restore dependencies
@@ -23,27 +29,29 @@ jobs:
       run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal
+    # Trusted publishing: exchange the workflow's OIDC token for a NuGet API
+    # key valid for 1 hour, matched against the trusted publishing policy on
+    # nuget.org (repository darinkes/SshNet.Keygen, workflow nuget.yml).
+    - name: NuGet login (OIDC, temporary API key)
+      uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+      id: nuget_login
+      with:
+        user: ${{secrets.NUGET_USER}}
     - name: publish on version change
       id: publish_nuget
-      uses: alirezanet/publish-nuget@v3.1.0
+      uses: alirezanet/publish-nuget@e276c40afeb2a154046f0997820f2a9ea74832d9 # v3.1.0
       with:
         # Filepath of the project to be packaged, relative to root of repository
         PROJECT_FILE_PATH: SshNet.Keygen/SshNet.Keygen.csproj
         # NuGet package id, used for version detection & defaults to project name
         PACKAGE_NAME: SshNet.Keygen
-        # Filepath with version info, relative to root of repository & defaults to PROJECT_FILE_PATH
-        # VERSION_FILE_PATH: Directory.Build.props
-        # Regex pattern to extract version info in a capturing group
-        # VERSION_REGEX: ^\s*<Version>(.*)<\/Version>\s*$
-        # Useful with external providers like Nerdbank.GitVersioning, ignores VERSION_FILE_PATH & VERSION_REGEX
-        # VERSION_STATIC: 1.0.0
         # Flag to toggle git tagging, enabled by default
         TAG_COMMIT: true
         # Format of the git tag, [*] gets replaced with actual version
         TAG_FORMAT: "*"
-        # API key to authenticate with NuGet server
-        NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+        # Temporary API key from the trusted publishing login above
+        NUGET_KEY: ${{steps.nuget_login.outputs.NUGET_API_KEY}}
         # NuGet server uri hosting the packages, defaults to https://api.nuget.org
         NUGET_SOURCE: https://api.nuget.org
         # Flag to toggle pushing symbols along with nuget package to the server, disabled by default
-        INCLUDE_SYMBOLS: false
+        INCLUDE_SYMBOLS: true


### PR DESCRIPTION
Replaces the long-lived `NUGET_API_KEY` secret with OIDC trusted publishing, matching SshNet.Agent.

- Adds `id-token: write` / `contents: write` permissions.
- `NuGet/login` exchanges the workflow's OIDC token for a 1-hour API key.
- Third-party actions pinned to commit SHAs; checkout/setup-dotnet bumped to v5.
- `INCLUDE_SYMBOLS: true` now that the package produces a snupkg (see the packaging PR).
- `submodules: recursive` preserved for the Chaos.NaCl build.

Requires the trusted-publishing policy on nuget.org (repo `darinkes/SshNet.Keygen`, workflow `nuget.yml`) and the `NUGET_USER` secret — both already prepared.