### PR TITLE
Polish NuGet packaging: SourceLink, symbols, README, cap SSH.NET

### DIFF
--- a/SshNet.Keygen/SshNet.Keygen.csproj
+++ b/SshNet.Keygen/SshNet.Keygen.csproj
@@ -10,21 +10,37 @@
         <PackageTags>ssh;scp;sftp</PackageTags>
         <Description>SSH.NET Extension to generate and export Authentication Keys in OpenSSH and PuTTY Format.</Description>
         <PackageReleaseNotes>https://github.com/darinkes/SshNet.Keygen/releases/tag/$(PackageVersion)</PackageReleaseNotes>
-        <Copyright>Copyright (c) 2021 - 2024 Stefan Rinkes</Copyright>
+        <Copyright>Copyright (c) 2021 - 2026 Stefan Rinkes</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/darinkes/SshNet.Keygen/</PackageProjectUrl>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <Authors>darinkes</Authors>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     </PropertyGroup>
+
+    <PropertyGroup Label="SourceLink and symbols">
+        <RepositoryUrl>https://github.com/darinkes/SshNet.Keygen</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="..\README.md" Pack="true" PackagePath="\" />
+    </ItemGroup>
 
     <ItemGroup>
         <Compile Include="..\Chaos.NaCl\Chaos.NaCl\**\*.cs" Exclude="..\Chaos.NaCl\Chaos.NaCl\Properties\*">
             <Link>Chaos.Nacl\%(RecursiveDir)%(Filename)%(Extension)</Link>
         </Compile>
 
-        <PackageReference Include="SSH.NET" Version="[2024.2.0,)" />
+        <PackageReference Include="SSH.NET" Version="[2024.2.0,2026.0)" />
         <PackageReference Include="Konscious.Security.Cryptography.Argon2" Version="1.3.0"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' != 'net48' ">


### PR DESCRIPTION
Brings the package metadata in line with SshNet.Agent:

- **SourceLink** (`Microsoft.SourceLink.GitHub`) + `PublishRepositoryUrl` / `EmbedUntrackedSources` / `ContinuousIntegrationBuild` for debuggable builds.
- **Symbols**: `IncludeSymbols` + `snupkg`.
- **README** packed into the package (`PackageReadmeFile`).
- **SSH.NET** capped to `[2024.2.0,2026.0)` so an untested future major isn't pulled in automatically.
- Copyright year → 2026.

Verified locally: `dotnet pack` emits both `.nupkg` and `.snupkg`, with README and both TFMs present.