### PR TITLE
Fix nullable warnings in the ECDSA private-key export

### DIFF
--- a/SshNet.Keygen/Extensions/KeyExtension.cs
+++ b/SshNet.Keygen/Extensions/KeyExtension.cs
@@ -132,7 +132,7 @@ namespace SshNet.Keygen.Extensions
                     var publicKey = ecdsa.Public;
                     privWriter.EncodeBinary(publicKey[0]);
                     privWriter.EncodeBinary(publicKey[1]);
-                    privWriter.EncodeBinary(ecdsa.PrivateKey.ToBigInteger2());
+                    privWriter.EncodeBinary(ecdsa.PrivateKey!.ToBigInteger2());
                     break;
                 default:
                     throw new NotSupportedException($"Unsupported KeyType: {key}");
@@ -221,7 +221,7 @@ namespace SshNet.Keygen.Extensions
                     // Fallthrough
                 case "ecdsa-sha2-nistp521":
                     var ecdsa = (EcdsaKey)key;
-                    privWriter.EncodeBinary(ecdsa.PrivateKey.ToBigInteger2());
+                    privWriter.EncodeBinary(ecdsa.PrivateKey!.ToBigInteger2());
                     break;
                 default:
                     throw new NotSupportedException($"Unsupported KeyType: {key}");


### PR DESCRIPTION
`EcdsaKey.PrivateKey` is `byte[]?` in SSH.NET, producing CS8604 (possible null argument) at the two ECDSA export sites. At these sites the key is fully populated, and `ToBigInteger2` dereferences `data[0]` immediately anyway, so a null would already NPE — the null-forgiving `!` documents the invariant without changing behavior.

Clears the two own-code nullable warnings. Full test suite (17 tests) passes.