### PR TITLE
Fix transitive System.Formats.Asn1 CVE (GHSA-447r-wph3-92pm)

### DIFF
--- a/SshNet.Keygen/SshNet.Keygen.csproj
+++ b/SshNet.Keygen/SshNet.Keygen.csproj
@@ -29,5 +29,7 @@
 
     <ItemGroup Condition=" '$(TargetFramework)' != 'net48' ">
         <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
+        <!-- force the vulnerable transitive up to a patched version (GHSA-447r-wph3-92pm) -->
+        <PackageReference Include="System.Formats.Asn1" Version="8.0.2" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #19.

`System.Security.Cryptography.Cng 5.0.0` (needed for `ECDsaCng`/`RSACng` on netstandard2.0) drags in `System.Formats.Asn1 5.0.0`, which has a High-severity advisory. A net8.0 consumer of the netstandard2.0 asset inherits it.

Fix: pin `System.Formats.Asn1` to the patched `8.0.2` in the non-net48 group, forcing the transitive up.

Verified with a net8.0 consumer:
- Before: `System.Formats.Asn1 5.0.0  High  GHSA-447r-wph3-92pm`
- After: no vulnerable packages; `System.Formats.Asn1` resolves to `8.0.2`.

Library test suite (17) still passes. Minimal, single-line change — no new target framework, unlike #20.