### PR TITLE
Add a net8.0 target

### DIFF
--- a/SshNet.Keygen/Extensions/EcdsaExtension.cs
+++ b/SshNet.Keygen/Extensions/EcdsaExtension.cs
@@ -29,8 +29,8 @@ namespace SshNet.Keygen.Extensions
 
         public static byte[] UncompressedCoords(this ECParameters ecdsaParameters)
         {
-            var qx = ecdsaParameters.Q.X;
-            var qy = ecdsaParameters.Q.Y;
+            var qx = ecdsaParameters.Q.X!;
+            var qy = ecdsaParameters.Q.Y!;
             return UncompressedCoords(qx, qy);
         }
 #else

--- a/SshNet.Keygen/Extensions/KeyExtension.cs
+++ b/SshNet.Keygen/Extensions/KeyExtension.cs
@@ -103,7 +103,7 @@ namespace SshNet.Keygen.Extensions
             var rnd = new Random().Next(0, int.MaxValue);
             privWriter.EncodeInt(rnd); // check-int1
             privWriter.EncodeInt(rnd); // check-int2
-            privWriter.EncodeBinary(key.ToString());
+            privWriter.EncodeBinary(key.ToString()!);
             switch (key.ToString())
             {
                 case "ssh-ed25519":
@@ -237,7 +237,7 @@ namespace SshNet.Keygen.Extensions
             // MAC
             using var macStream = new MemoryStream();
             using var macWriter = new BinaryWriter(macStream);
-            macWriter.EncodeBinary(key.ToString());
+            macWriter.EncodeBinary(key.ToString()!);
             macWriter.EncodeBinary(encryption.CipherName);
             macWriter.EncodeBinary(key.Comment);
             macWriter.EncodeBinary(pubStream);
@@ -261,7 +261,7 @@ namespace SshNet.Keygen.Extensions
             else
             {
                 puttyV3Encryption = encryption.PuttyV3Encrypt(privStream.ToArray());
-                privateBase64String = Convert.ToBase64String(puttyV3Encryption.Result).FormatNewLines(64);
+                privateBase64String = Convert.ToBase64String(puttyV3Encryption.Result!).FormatNewLines(64);
 
                 using var hmac = new HMACSHA256(puttyV3Encryption.MacKey);
                 macHash = hmac.ComputeHash(hashData);
@@ -305,7 +305,7 @@ namespace SshNet.Keygen.Extensions
 
         private static void PublicKeyData(this Key key, BinaryWriter writer)
         {
-            writer.EncodeBinary(key.ToString());
+            writer.EncodeBinary(key.ToString()!);
             switch (key.ToString())
             {
                 case "ssh-ed25519":

--- a/SshNet.Keygen/SshKey.cs
+++ b/SshNet.Keygen/SshKey.cs
@@ -65,12 +65,12 @@ namespace SshNet.Keygen
                     var rsaParameters = rsa.ExportParameters(true);
 
                     key = new RsaKey(
-                        rsaParameters.Modulus.ToBigInteger2().ToByteArray().Reverse().ToBigInteger(),
-                        rsaParameters.Exponent.ToBigInteger2().ToByteArray().Reverse().ToBigInteger(),
-                        rsaParameters.D.ToBigInteger2().ToByteArray().Reverse().ToBigInteger(),
-                        rsaParameters.P.ToBigInteger2().ToByteArray().Reverse().ToBigInteger(),
-                        rsaParameters.Q.ToBigInteger2().ToByteArray().Reverse().ToBigInteger(),
-                        rsaParameters.InverseQ.ToBigInteger2().ToByteArray().Reverse().ToBigInteger()
+                        rsaParameters.Modulus!.ToBigInteger2().ToByteArray().Reverse().ToBigInteger(),
+                        rsaParameters.Exponent!.ToBigInteger2().ToByteArray().Reverse().ToBigInteger(),
+                        rsaParameters.D!.ToBigInteger2().ToByteArray().Reverse().ToBigInteger(),
+                        rsaParameters.P!.ToBigInteger2().ToByteArray().Reverse().ToBigInteger(),
+                        rsaParameters.Q!.ToBigInteger2().ToByteArray().Reverse().ToBigInteger(),
+                        rsaParameters.InverseQ!.ToBigInteger2().ToByteArray().Reverse().ToBigInteger()
                     );
                     break;
                 }
@@ -94,7 +94,7 @@ namespace SshNet.Keygen
                     key = new EcdsaKey(
                         ecdsa.EcCurveNameSshCompat(),
                         ecdsaParameters.UncompressedCoords(),
-                        ecdsaParameters.D
+                        ecdsaParameters.D!
                     );
 #else
                     using var ecdsa = new ECDsaCng(info.KeyLength);
@@ -132,6 +132,10 @@ namespace SshNet.Keygen
             {
                 throw new CryptographicException($"Illegal Key Size: {keySize}");
             }
+            return rsa;
+#elif NET8_0_OR_GREATER
+            var rsa = RSA.Create();
+            rsa.KeySize = keySize;
             return rsa;
 #else
             var rsa = RSA.Create();

--- a/SshNet.Keygen/SshNet.Keygen.csproj
+++ b/SshNet.Keygen/SshNet.Keygen.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net48;netstandard2.0</TargetFrameworks>
-        <TargetFramework Condition="'$(OS)' != 'Windows_NT'">netstandard2.0</TargetFramework>
+        <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net48;netstandard2.0;net8.0</TargetFrameworks>
+        <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;net8.0</TargetFrameworks>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <PackageId>SshNet.Keygen</PackageId>
@@ -17,6 +17,11 @@
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <Authors>darinkes</Authors>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    </PropertyGroup>
+
+    <!-- net8.0 has the netstandard APIs; reuse the portable (non-CNG) code paths gated on NETSTANDARD -->
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
     </PropertyGroup>
 
     <PropertyGroup Label="SourceLink and symbols">
@@ -43,7 +48,7 @@
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
     </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' != 'net48' ">
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
         <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
         <!-- force the vulnerable transitive up to a patched version (GHSA-447r-wph3-92pm) -->
         <PackageReference Include="System.Formats.Asn1" Version="8.0.2" />


### PR DESCRIPTION
Adds `net8.0` alongside `net48` and `netstandard2.0`, so modern consumers get a native assembly instead of the netstandard2.0 fallback.

- Define `NETSTANDARD` for net8.0 so ECDSA/RSA use the existing portable (cross-platform) code paths — no `ECDsaCng`/`RSACng`, no CA1416 platform warnings.
- `CreateRSA` gets a net8.0 branch (`RSA.Create()` + `KeySize`) that avoids the Windows-only `RSACng`.
- Scope `System.Security.Cryptography.Cng` (+ the Asn1 pin) to **netstandard2.0 only** — net8.0 has these in the BCL.

Result: the net8.0 dependency group carries only SSH.NET — no CNG package, no `System.Formats.Asn1` (so no CVE surface there at all), while netstandard2.0 keeps the patched CNG+Asn1 for .NET Framework consumers.

Also cleared the net8.0-only nullable warnings (BCL annotates freshly-generated key material / `ToString()` as nullable) with `!`, matching #25.

Verified: all three TFMs build clean (own code), package ships lib/net8.0, 17/17 tests pass on the net8.0 asset.