### PR TITLE
Document the public API and make missing docs an error

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+# Undocumented public members are an error, so the public API stays documented.
+[*.cs]
+dotnet_diagnostic.CS1591.severity = error
+
+# Vendored submodule — not part of our documented public API.
+[Chaos.NaCl/**/*.cs]
+dotnet_diagnostic.CS1591.severity = none

--- a/SshNet.Keygen/Extensions/KeyExtension.cs
+++ b/SshNet.Keygen/Extensions/KeyExtension.cs
@@ -7,6 +7,9 @@ using SshNet.Keygen.SshKeyEncryption;
 
 namespace SshNet.Keygen.Extensions
 {
+    /// <summary>
+    /// Internal formatting helpers for SSH.NET <c>Key</c> instances.
+    /// </summary>
     public static class KeyExtension
     {
         #region Fingerprint

--- a/SshNet.Keygen/Extensions/PrivateKeyFileExtension.cs
+++ b/SshNet.Keygen/Extensions/PrivateKeyFileExtension.cs
@@ -1,19 +1,27 @@
-﻿using System.Linq;
+using System.Linq;
 using Renci.SshNet;
 using Renci.SshNet.Security;
 using SshNet.Keygen.SshKeyEncryption;
 
 namespace SshNet.Keygen.Extensions
 {
+    /// <summary>
+    /// Export and fingerprint helpers for any SSH.NET <see cref="IPrivateKeySource"/>.
+    /// </summary>
     public static class PrivateKeyFileExtension
     {
         #region Fingerprint
 
+        /// <summary>Returns the key fingerprint using the default hash algorithm.</summary>
+        /// <param name="keyFile">The key.</param>
         public static string Fingerprint(this IPrivateKeySource keyFile)
         {
             return keyFile.Fingerprint(SshKeyGenerateInfo.DefaultHashAlgorithmName);
         }
 
+        /// <summary>Returns the key fingerprint using the given hash algorithm.</summary>
+        /// <param name="keyFile">The key.</param>
+        /// <param name="hashAlgorithm">The hash algorithm to use.</param>
         public static string Fingerprint(this IPrivateKeySource keyFile, SshKeyHashAlgorithmName hashAlgorithm)
         {
             return ((KeyHostAlgorithm) keyFile.HostKeyAlgorithms.First()).Key.Fingerprint(hashAlgorithm);
@@ -23,6 +31,8 @@ namespace SshNet.Keygen.Extensions
 
         #region Public
 
+        /// <summary>Returns the public key. For a generated key the source's format is used, otherwise OpenSSH.</summary>
+        /// <param name="keyFile">The key.</param>
         public static string ToPublic(this IPrivateKeySource keyFile)
         {
             var keyFormat = SshKeyGenerateInfo.DefaultSshKeyFormat;
@@ -32,6 +42,9 @@ namespace SshNet.Keygen.Extensions
             return keyFile.ToPublic(keyFormat);
         }
 
+        /// <summary>Returns the public key in the given format.</summary>
+        /// <param name="keyFile">The key.</param>
+        /// <param name="sshKeyFormat">The public key format.</param>
         public static string ToPublic(this IPrivateKeySource keyFile, SshKeyFormat sshKeyFormat)
         {
             return sshKeyFormat is SshKeyFormat.PuTTYv2 or SshKeyFormat.PuTTYv3
@@ -39,11 +52,15 @@ namespace SshNet.Keygen.Extensions
                 : ((KeyHostAlgorithm) keyFile.HostKeyAlgorithms.First()).Key.ToPublic();
         }
 
+        /// <summary>Returns the public key in OpenSSH format.</summary>
+        /// <param name="keyFile">The key.</param>
         public static string ToOpenSshPublicFormat(this IPrivateKeySource keyFile)
         {
             return keyFile.ToPublic(SshKeyFormat.OpenSSH);
         }
 
+        /// <summary>Returns the public key in PuTTY format.</summary>
+        /// <param name="keyFile">The key.</param>
         public static string ToPuttyPublicFormat(this IPrivateKeySource keyFile)
         {
             return ((KeyHostAlgorithm) keyFile.HostKeyAlgorithms.First()).Key.ToPuttyPublicFormat();
@@ -53,6 +70,8 @@ namespace SshNet.Keygen.Extensions
 
         #region OpenSshFormat
 
+        /// <summary>Returns the private key in OpenSSH format. For a generated key the source's encryption is used.</summary>
+        /// <param name="keyFile">The key.</param>
         public static string ToOpenSshFormat(this IPrivateKeySource keyFile)
         {
             var encryption = SshKeyGenerateInfo.DefaultSshKeyEncryption;
@@ -62,11 +81,17 @@ namespace SshNet.Keygen.Extensions
             return keyFile.ToOpenSshFormat(encryption);
         }
 
+        /// <summary>Returns the private key in OpenSSH format, encrypted with the given passphrase (AES-256).</summary>
+        /// <param name="keyFile">The key.</param>
+        /// <param name="passphrase">The passphrase to encrypt with.</param>
         public static string ToOpenSshFormat(this IPrivateKeySource keyFile, string passphrase)
         {
             return keyFile.ToOpenSshFormat(new SshKeyEncryptionAes256(passphrase));
         }
 
+        /// <summary>Returns the private key in OpenSSH format using the given encryption.</summary>
+        /// <param name="keyFile">The key.</param>
+        /// <param name="encryption">The encryption to apply.</param>
         public static string ToOpenSshFormat(this IPrivateKeySource keyFile, ISshKeyEncryption encryption)
         {
             return ((KeyHostAlgorithm) keyFile.HostKeyAlgorithms.First()).Key.ToOpenSshFormat(encryption);
@@ -76,6 +101,8 @@ namespace SshNet.Keygen.Extensions
 
         #region PuttyFormat
 
+        /// <summary>Returns the private key in PuTTY format. For a generated PuTTY key the source's format is used, otherwise PuTTY v3.</summary>
+        /// <param name="keyFile">The key.</param>
         public static string ToPuttyFormat(this IPrivateKeySource keyFile)
         {
             var sshKeyFormat = SshKeyFormat.PuTTYv3;
@@ -88,16 +115,26 @@ namespace SshNet.Keygen.Extensions
             return keyFile.ToPuttyFormat(sshKeyFormat);
         }
 
+        /// <summary>Returns the private key in PuTTY v3 format, encrypted with the given passphrase (AES-256).</summary>
+        /// <param name="keyFile">The key.</param>
+        /// <param name="passphrase">The passphrase to encrypt with.</param>
         public static string ToPuttyFormat(this IPrivateKeySource keyFile, string passphrase)
         {
             return keyFile.ToPuttyFormat(new SshKeyEncryptionAes256(passphrase), SshKeyFormat.PuTTYv3);
         }
 
+        /// <summary>Returns the private key in the given PuTTY format, encrypted with the given passphrase (AES-256).</summary>
+        /// <param name="keyFile">The key.</param>
+        /// <param name="passphrase">The passphrase to encrypt with.</param>
+        /// <param name="sshKeyFormat">The PuTTY key format.</param>
         public static string ToPuttyFormat(this IPrivateKeySource keyFile, string passphrase, SshKeyFormat sshKeyFormat)
         {
             return keyFile.ToPuttyFormat(new SshKeyEncryptionAes256(passphrase), sshKeyFormat);
         }
 
+        /// <summary>Returns the private key in the given PuTTY format. For a generated key the source's encryption is used.</summary>
+        /// <param name="keyFile">The key.</param>
+        /// <param name="sshKeyFormat">The PuTTY key format.</param>
         public static string ToPuttyFormat(this IPrivateKeySource keyFile, SshKeyFormat sshKeyFormat)
         {
             var encryption = SshKeyGenerateInfo.DefaultSshKeyEncryption;
@@ -107,11 +144,18 @@ namespace SshNet.Keygen.Extensions
             return keyFile.ToPuttyFormat(encryption, sshKeyFormat);
         }
 
+        /// <summary>Returns the private key in PuTTY v3 format using the given encryption.</summary>
+        /// <param name="keyFile">The key.</param>
+        /// <param name="encryption">The encryption to apply.</param>
         public static string ToPuttyFormat(this IPrivateKeySource keyFile, ISshKeyEncryption encryption)
         {
             return keyFile.ToPuttyFormat(encryption, SshKeyFormat.PuTTYv3);
         }
 
+        /// <summary>Returns the private key in the given PuTTY format using the given encryption.</summary>
+        /// <param name="keyFile">The key.</param>
+        /// <param name="encryption">The encryption to apply.</param>
+        /// <param name="sshKeyFormat">The PuTTY key format.</param>
         public static string ToPuttyFormat(this IPrivateKeySource keyFile, ISshKeyEncryption encryption, SshKeyFormat sshKeyFormat)
         {
             return ((KeyHostAlgorithm) keyFile.HostKeyAlgorithms.First()).Key.ToPuttyFormat(encryption, sshKeyFormat);

--- a/SshNet.Keygen/GeneratedPrivateKey.cs
+++ b/SshNet.Keygen/GeneratedPrivateKey.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Security.Cryptography;
 using Renci.SshNet;
 using Renci.SshNet.Security;
@@ -6,16 +6,25 @@ using Renci.SshNet.Security.Cryptography;
 
 namespace SshNet.Keygen
 {
+    /// <summary>
+    /// A freshly generated key, usable directly as an SSH.NET <see cref="IPrivateKeySource"/>.
+    /// </summary>
     public class GeneratedPrivateKey : IPrivateKeySource
     {
         private readonly List<HostAlgorithm> _hostAlgorithms = new();
 
+        /// <summary>The host key algorithms this key supports.</summary>
         public IReadOnlyCollection<HostAlgorithm> HostKeyAlgorithms => _hostAlgorithms;
 
+        /// <summary>The generated key.</summary>
         public Key Key { get; }
 
+        /// <summary>The options the key was generated with.</summary>
         public SshKeyGenerateInfo Info { get; }
 
+        /// <summary>Wraps a generated <paramref name="key"/> together with the <paramref name="info"/> it was created from.</summary>
+        /// <param name="key">The generated key.</param>
+        /// <param name="info">The options the key was generated with.</param>
         public GeneratedPrivateKey(Key key, SshKeyGenerateInfo info)
         {
             Key = key;

--- a/SshNet.Keygen/SshKey.cs
+++ b/SshNet.Keygen/SshKey.cs
@@ -7,19 +7,32 @@ using SshNet.Keygen.Extensions;
 
 namespace SshNet.Keygen
 {
+    /// <summary>
+    /// Generates SSH authentication keys (RSA, ECDSA, Ed25519).
+    /// </summary>
     public static class SshKey
     {
+        /// <summary>Generates a default key and writes it to <paramref name="path"/>.</summary>
+        /// <param name="path">Destination file path.</param>
+        /// <param name="mode">How the destination file is opened.</param>
         public static GeneratedPrivateKey Generate(string path, FileMode mode)
         {
             return Generate(path, mode, new SshKeyGenerateInfo());
         }
 
+        /// <summary>Generates a key per <paramref name="info"/> and writes it to <paramref name="path"/>.</summary>
+        /// <param name="path">Destination file path.</param>
+        /// <param name="mode">How the destination file is opened.</param>
+        /// <param name="info">Generation and export options.</param>
         public static GeneratedPrivateKey Generate(string path, FileMode mode, SshKeyGenerateInfo info)
         {
             using var file = File.Open(path, mode, FileAccess.Write);
             return Generate(file, info);
         }
 
+        /// <summary>Generates a key per <paramref name="info"/> and writes it to <paramref name="stream"/>.</summary>
+        /// <param name="stream">Destination stream.</param>
+        /// <param name="info">Generation and export options.</param>
         public static GeneratedPrivateKey Generate(Stream stream, SshKeyGenerateInfo info)
         {
             using var writer = new StreamWriter(stream);
@@ -40,11 +53,14 @@ namespace SshNet.Keygen
             return key;
         }
 
+        /// <summary>Generates a default key (2048-bit RSA) in memory.</summary>
         public static GeneratedPrivateKey Generate()
         {
             return Generate(new SshKeyGenerateInfo());
         }
 
+        /// <summary>Generates a key per <paramref name="info"/> in memory.</summary>
+        /// <param name="info">Generation and export options.</param>
         public static GeneratedPrivateKey Generate(SshKeyGenerateInfo info)
         {
             Key key;

--- a/SshNet.Keygen/SshKeyEncryption/ISshKeyEncryption.cs
+++ b/SshNet.Keygen/SshKeyEncryption/ISshKeyEncryption.cs
@@ -1,27 +1,53 @@
-﻿namespace SshNet.Keygen.SshKeyEncryption
+namespace SshNet.Keygen.SshKeyEncryption
 {
+    /// <summary>
+    /// Encrypts private key material when a key is exported.
+    /// </summary>
     public interface ISshKeyEncryption
     {
+        /// <summary>Name of the cipher as written into the key file (for example <c>aes256-ctr</c> or <c>none</c>).</summary>
         public string CipherName { get; }
 
+        /// <summary>Name of the key-derivation function as written into the key file (for example <c>bcrypt</c> or <c>none</c>).</summary>
         public string KdfName { get; }
 
+        /// <summary>Cipher block size, in bytes, used for padding.</summary>
         public int BlockSize { get; }
 
+        /// <summary>The passphrase protecting the key, or an empty string when unencrypted.</summary>
         public string Passphrase { get; }
 
+        /// <summary>Returns the KDF options (salt, rounds, ...) written into the OpenSSH key file.</summary>
         public byte[] KdfOptions();
 
+        /// <summary>Encrypts <paramref name="data"/>.</summary>
+        /// <param name="data">The plaintext to encrypt.</param>
         public byte[] Encrypt(byte[] data);
 
+        /// <summary>Encrypts <paramref name="length"/> bytes of <paramref name="data"/> starting at <paramref name="offset"/>.</summary>
+        /// <param name="data">The buffer to encrypt from.</param>
+        /// <param name="offset">Start offset within <paramref name="data"/>.</param>
+        /// <param name="length">Number of bytes to encrypt.</param>
         public byte[] Encrypt(byte[] data, int offset, int length);
 
+        /// <summary>Encrypts <paramref name="data"/> for the PuTTY v2 key format.</summary>
+        /// <param name="data">The plaintext to encrypt.</param>
         public byte[] PuttyV2Encrypt(byte[] data);
 
+        /// <summary>Encrypts <paramref name="length"/> bytes of <paramref name="data"/> starting at <paramref name="offset"/> for the PuTTY v2 key format.</summary>
+        /// <param name="data">The buffer to encrypt from.</param>
+        /// <param name="offset">Start offset within <paramref name="data"/>.</param>
+        /// <param name="length">Number of bytes to encrypt.</param>
         public byte[] PuttyV2Encrypt(byte[] data, int offset, int length);
 
+        /// <summary>Encrypts <paramref name="data"/> for the PuTTY v3 key format.</summary>
+        /// <param name="data">The plaintext to encrypt.</param>
         public PuttyV3Encryption PuttyV3Encrypt(byte[] data);
 
+        /// <summary>Encrypts <paramref name="length"/> bytes of <paramref name="data"/> starting at <paramref name="offset"/> for the PuTTY v3 key format.</summary>
+        /// <param name="data">The buffer to encrypt from.</param>
+        /// <param name="offset">Start offset within <paramref name="data"/>.</param>
+        /// <param name="length">Number of bytes to encrypt.</param>
         public PuttyV3Encryption PuttyV3Encrypt(byte[] data, int offset, int length);
     }
 }

--- a/SshNet.Keygen/SshKeyEncryption/PuttyV3Encryption.cs
+++ b/SshNet.Keygen/SshKeyEncryption/PuttyV3Encryption.cs
@@ -1,23 +1,42 @@
 namespace SshNet.Keygen.SshKeyEncryption
 {
+    /// <summary>
+    /// The Argon2 variant used to derive the encryption key for a PuTTY v3 key file.
+    /// </summary>
     public enum ArgonKeyDerivation
     {
+        /// <summary>Argon2d (data-dependent).</summary>
         Argon2d,
+
+        /// <summary>Argon2i (data-independent).</summary>
         Argon2i,
+
+        /// <summary>Argon2id (hybrid, recommended default).</summary>
         Argon2id
     }
 
+    /// <summary>
+    /// Argon2 parameters for PuTTY v3 key encryption.
+    /// </summary>
     public class PuttyV3Encryption
     {
         internal byte[]? Result;
         internal byte[] MacKey;
         internal byte[]? Salt;
 
+        /// <summary>The Argon2 variant to use. Defaults to <see cref="ArgonKeyDerivation.Argon2id"/>.</summary>
         public ArgonKeyDerivation KeyDerivation = ArgonKeyDerivation.Argon2id;
+
+        /// <summary>Argon2 degree of parallelism (lanes). Defaults to <c>1</c>.</summary>
         public int DegreeOfParallelism = 1;
+
+        /// <summary>Argon2 memory size in kibibytes. Defaults to <c>8192</c>.</summary>
         public int MemorySize = 8192;
+
+        /// <summary>Argon2 iteration (pass) count. Defaults to <c>22</c>.</summary>
         public int Iterations = 22;
 
+        /// <summary>Initializes a new instance with the default Argon2id parameters.</summary>
         public PuttyV3Encryption()
         {
             MacKey = new byte[0];

--- a/SshNet.Keygen/SshKeyEncryption/SshKeyEncryptionAes256.cs
+++ b/SshNet.Keygen/SshKeyEncryption/SshKeyEncryptionAes256.cs
@@ -11,18 +11,32 @@ using SshNet.Keygen.Extensions;
 
 namespace SshNet.Keygen.SshKeyEncryption
 {
+    /// <summary>
+    /// The AES-256 cipher mode used to encrypt a key.
+    /// </summary>
     public enum Aes256Mode
     {
+        /// <summary>Cipher Block Chaining.</summary>
         CBC,
+
+        /// <summary>Counter mode.</summary>
         CTR
     }
 
+    /// <summary>
+    /// Encrypts a key with AES-256 (bcrypt KDF for OpenSSH, Argon2 for PuTTY v3).
+    /// </summary>
     public class SshKeyEncryptionAes256 : ISshKeyEncryption
     {
+        /// <inheritdoc />
         public string CipherName => $"aes256-{_mode.ToString().ToLower()}";
+        /// <inheritdoc />
         public string KdfName => "bcrypt";
+        /// <inheritdoc />
         public int BlockSize => 16;
+        /// <inheritdoc />
         public string Passphrase => _passphrase;
+        /// <summary>The Argon2 parameters applied when exporting to the PuTTY v3 format.</summary>
         public PuttyV3Encryption PuttyV3Encryption => _puttyV3Encryption;
 
         private const int SaltLen = 16;
@@ -33,6 +47,9 @@ namespace SshNet.Keygen.SshKeyEncryption
         private readonly string _passphrase;
         private readonly PuttyV3Encryption _puttyV3Encryption;
 
+        /// <summary>Initializes AES-256 encryption with the given passphrase.</summary>
+        /// <param name="passphrase">The passphrase protecting the key.</param>
+        /// <param name="puttyV3Encryption">Optional Argon2 parameters for PuTTY v3 export; defaults are used when null.</param>
         public SshKeyEncryptionAes256(string passphrase, PuttyV3Encryption? puttyV3Encryption = null)
         {
             _passphrase = passphrase;
@@ -41,12 +58,17 @@ namespace SshNet.Keygen.SshKeyEncryption
             _puttyV3Encryption = puttyV3Encryption ?? new PuttyV3Encryption();
         }
 
+        /// <summary>Initializes AES-256 encryption with the given passphrase and cipher mode.</summary>
+        /// <param name="passphrase">The passphrase protecting the key.</param>
+        /// <param name="mode">The AES cipher mode.</param>
+        /// <param name="puttyV3Encryption">Optional Argon2 parameters for PuTTY v3 export; defaults are used when null.</param>
         public SshKeyEncryptionAes256(string passphrase, Aes256Mode mode, PuttyV3Encryption? puttyV3Encryption = null)
          : this(passphrase, puttyV3Encryption)
         {
             _mode = mode;
         }
 
+        /// <inheritdoc />
         public byte[] KdfOptions()
         {
             using var stream = new MemoryStream();
@@ -58,6 +80,7 @@ namespace SshNet.Keygen.SshKeyEncryption
             return stream.ToArray();
         }
 
+        /// <inheritdoc />
         public byte[] Encrypt(byte[] data)
         {
             var keyiv = new byte[48];
@@ -82,6 +105,7 @@ namespace SshNet.Keygen.SshKeyEncryption
             return cipher.Encrypt(data);
         }
 
+        /// <inheritdoc />
         public byte[] Encrypt(byte[] data, int offset, int length)
         {
             var buffer = new byte[length];
@@ -89,6 +113,7 @@ namespace SshNet.Keygen.SshKeyEncryption
             return Encrypt(buffer);
         }
 
+        /// <inheritdoc />
         public byte[] PuttyV2Encrypt(byte[] data)
         {
             using var sha1 = SHA1.Create();
@@ -124,6 +149,7 @@ namespace SshNet.Keygen.SshKeyEncryption
             return cipher.Encrypt(data);
         }
 
+        /// <inheritdoc />
         public byte[] PuttyV2Encrypt(byte[] data, int offset, int length)
         {
             var buffer = new byte[length];
@@ -131,6 +157,7 @@ namespace SshNet.Keygen.SshKeyEncryption
             return PuttyV2Encrypt(buffer);
         }
 
+        /// <inheritdoc />
         public PuttyV3Encryption PuttyV3Encrypt(byte[] data)
         {
             Argon2 argon2 = _puttyV3Encryption.KeyDerivation switch
@@ -175,6 +202,7 @@ namespace SshNet.Keygen.SshKeyEncryption
             return _puttyV3Encryption;
         }
 
+        /// <inheritdoc />
         public PuttyV3Encryption PuttyV3Encrypt(byte[] data, int offset, int length)
         {
             var buffer = new byte[length];

--- a/SshNet.Keygen/SshKeyEncryption/SshKeyEncryptionAlgorithm.cs
+++ b/SshNet.Keygen/SshKeyEncryption/SshKeyEncryptionAlgorithm.cs
@@ -1,14 +1,26 @@
-﻿using System;
+using System;
 using System.Security.Cryptography;
 
 namespace SshNet.Keygen.SshKeyEncryption
 {
+    /// <summary>
+    /// The hash algorithm used to compute a key fingerprint.
+    /// </summary>
     public enum SshKeyHashAlgorithmName
     {
+        /// <summary>MD5.</summary>
         MD5,
+
+        /// <summary>SHA-1.</summary>
         SHA1,
+
+        /// <summary>SHA-256.</summary>
         SHA256,
+
+        /// <summary>SHA-384.</summary>
         SHA384,
+
+        /// <summary>SHA-512.</summary>
         SHA512
     }
 

--- a/SshNet.Keygen/SshKeyEncryption/SshKeyEncryptionNone.cs
+++ b/SshNet.Keygen/SshKeyEncryption/SshKeyEncryptionNone.cs
@@ -1,24 +1,34 @@
-﻿using System;
+using System;
 
 namespace SshNet.Keygen.SshKeyEncryption
 {
+    /// <summary>
+    /// No-op encryption: exports the key unencrypted.
+    /// </summary>
     public class SshKeyEncryptionNone : ISshKeyEncryption
     {
+        /// <inheritdoc />
         public string CipherName => "none";
+        /// <inheritdoc />
         public string KdfName => "none";
+        /// <inheritdoc />
         public int BlockSize => 8;
+        /// <inheritdoc />
         public string Passphrase => "";
 
+        /// <inheritdoc />
         public byte[] KdfOptions()
         {
             return new byte[] { };
         }
 
+        /// <inheritdoc />
         public byte[] Encrypt(byte[] data)
         {
             return data;
         }
 
+        /// <inheritdoc />
         public byte[] Encrypt(byte[] data, int offset, int length)
         {
             var buffer = new byte[length];
@@ -26,21 +36,25 @@ namespace SshNet.Keygen.SshKeyEncryption
             return Encrypt(buffer);
         }
 
+        /// <inheritdoc />
         public byte[] PuttyV2Encrypt(byte[] data)
         {
             return Encrypt(data);
         }
 
+        /// <inheritdoc />
         public byte[] PuttyV2Encrypt(byte[] data, int offset, int length)
         {
             return Encrypt(data, offset, length);
         }
 
+        /// <inheritdoc />
         public PuttyV3Encryption PuttyV3Encrypt(byte[] data)
         {
             return new PuttyV3Encryption { Result = Encrypt(data) };
         }
 
+        /// <inheritdoc />
         public PuttyV3Encryption PuttyV3Encrypt(byte[] data, int offset, int length)
         {
             return new PuttyV3Encryption { Result = Encrypt(data, offset, length) };

--- a/SshNet.Keygen/SshKeyFormat.cs
+++ b/SshNet.Keygen/SshKeyFormat.cs
@@ -1,9 +1,17 @@
-﻿namespace SshNet.Keygen
+namespace SshNet.Keygen
 {
+    /// <summary>
+    /// The on-disk format a key is written in.
+    /// </summary>
     public enum SshKeyFormat
     {
+        /// <summary>OpenSSH private key format.</summary>
         OpenSSH,
+
+        /// <summary>PuTTY private key format, version 2.</summary>
         PuTTYv2,
+
+        /// <summary>PuTTY private key format, version 3.</summary>
         PuTTYv3,
     }
 }

--- a/SshNet.Keygen/SshKeyGenerateInfo.cs
+++ b/SshNet.Keygen/SshKeyGenerateInfo.cs
@@ -1,36 +1,56 @@
-﻿using System;
+using System;
 using SshNet.Keygen.SshKeyEncryption;
 
 namespace SshNet.Keygen
 {
+    /// <summary>
+    /// Options controlling how a key is generated and exported.
+    /// </summary>
     public class SshKeyGenerateInfo
     {
+        /// <summary>Default fingerprint hash algorithm (<see cref="SshKeyHashAlgorithmName.SHA256"/>).</summary>
         public const SshKeyHashAlgorithmName DefaultHashAlgorithmName = SshKeyHashAlgorithmName.SHA256;
 
+        /// <summary>Default encryption (none — the key is exported unencrypted).</summary>
         public static readonly ISshKeyEncryption DefaultSshKeyEncryption = new SshKeyEncryptionNone();
 
+        /// <summary>Default key comment (<c>user@machine</c>).</summary>
         public static readonly string DefaultSshKeyComment = $"{Environment.UserName}@{Environment.MachineName}";
 
+        /// <summary>Default key format (<see cref="SshKeyFormat.OpenSSH"/>).</summary>
         public const SshKeyFormat DefaultSshKeyFormat = SshKeyFormat.OpenSSH;
 
+        /// <summary>Default key type (<see cref="SshKeyType.RSA"/>).</summary>
         public const SshKeyType DefaultSshKeyType = SshKeyType.RSA;
 
+        /// <summary>Default ECDSA key length, in bits.</summary>
         public const int DefaultEcdsaSshKeyLength = 256;
 
+        /// <summary>Default Ed25519 key length, in bits.</summary>
         public const int DefaultEd25519SshKeyLength = 256;
 
+        /// <summary>Default RSA key length, in bits.</summary>
         public const int DefaultRsaSshKeyLength = 2048;
 
+        /// <summary>Encryption applied when the key is exported.</summary>
         public ISshKeyEncryption Encryption { get; set; }
 
+        /// <summary>Comment stored with the key.</summary>
         public string Comment { get; set; }
 
+        /// <summary>Format the key is exported in.</summary>
         public SshKeyFormat KeyFormat { get; set; }
 
+        /// <summary>Key length in bits. Ignored for Ed25519.</summary>
         public int KeyLength { get; set; }
 
+        /// <summary>The key algorithm to generate.</summary>
         public SshKeyType KeyType { get; set; }
 
+        /// <summary>
+        /// Initializes generation options for the given key type, applying the matching default key length.
+        /// </summary>
+        /// <param name="keyType">The key algorithm to generate.</param>
         public SshKeyGenerateInfo(SshKeyType keyType = DefaultSshKeyType)
         {
             Encryption = DefaultSshKeyEncryption;

--- a/SshNet.Keygen/SshKeyType.cs
+++ b/SshNet.Keygen/SshKeyType.cs
@@ -1,9 +1,17 @@
-﻿namespace SshNet.Keygen
+namespace SshNet.Keygen
 {
+    /// <summary>
+    /// The asymmetric key algorithm to generate.
+    /// </summary>
     public enum SshKeyType
     {
+        /// <summary>RSA key.</summary>
         RSA,
+
+        /// <summary>ECDSA (NIST curve) key.</summary>
         ECDSA,
+
+        /// <summary>Ed25519 key.</summary>
         ED25519
     }
 }

--- a/SshNet.Keygen/SshNet.Keygen.csproj
+++ b/SshNet.Keygen/SshNet.Keygen.csproj
@@ -4,6 +4,8 @@
         <TargetFramework Condition="'$(OS)' != 'Windows_NT'">netstandard2.0</TargetFramework>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
+        <!-- docs enforced via .editorconfig (CS1591 = error for our code, none for vendored) -->
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageId>SshNet.Keygen</PackageId>
         <Version>2024.2.0.1</Version>
         <PackageVersion>$(Version)</PackageVersion>


### PR DESCRIPTION
Ports the Agent's documented-API guarantee to Keygen.

- XML doc comments on the entire public surface: `SshKey`, `SshKeyGenerateInfo`, `GeneratedPrivateKey`, `PrivateKeyFileExtension`, `ISshKeyEncryption` (+ `<inheritdoc/>` on the two implementations), and the `SshKeyType`/`SshKeyFormat`/`Aes256Mode`/`ArgonKeyDerivation`/`SshKeyHashAlgorithmName` enums.
- `GenerateDocumentationFile=true` so the XML docs ship in the package (verified: lib/*/SshNet.Keygen.xml present).
- Enforcement via `.editorconfig`: CS1591 is an **error** for our code, **none** for the vendored Chaos.NaCl submodule. (Driven by editorconfig rather than `WarningsAsErrors` so the vendored path can be scoped out — an explicit `WarningsAsErrors=CS1591` would re-elevate it there.)

Verified: all TFMs build clean; removing any doc comment fails the build with CS1591; package ships the .xml docs.