### PR TITLE
Prepare the 2024.2.0.2 release

### DIFF
--- a/SshNet.Keygen/SshNet.Keygen.csproj
+++ b/SshNet.Keygen/SshNet.Keygen.csproj
@@ -5,7 +5,7 @@
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <PackageId>SshNet.Keygen</PackageId>
-        <Version>2024.2.0.1</Version>
+        <Version>2024.2.0.2</Version>
         <PackageVersion>$(Version)</PackageVersion>
         <PackageTags>ssh;scp;sftp</PackageTags>
         <Description>SSH.NET Extension to generate and export Authentication Keys in OpenSSH and PuTTY Format.</Description>


### PR DESCRIPTION
Bumps `<Version>` to `2024.2.0.2`. Merging this to `main` triggers the trusted-publishing workflow, which packs the current `main` and publishes to NuGet (and tags the release).

**Merge this LAST** — after #34, #35 and #36 — so the published 2024.2.0.2 includes:
- the System.Formats.Asn1 CVE fix (already on main),
- the net8.0 target (#35),
- the documented public API (#36),
- the NUnit/Konscious bumps (#34).

This is also the first run of the OIDC trusted-publishing workflow, so it validates that setup end-to-end.

Diff is the single version line.