### PR TITLE
TEST (do not merge): confirm CI doc enforcement

### DIFF
--- a/SshNet.Keygen/SshKeyType.cs
+++ b/SshNet.Keygen/SshKeyType.cs
@@ -5,7 +5,6 @@ namespace SshNet.Keygen
     /// </summary>
     public enum SshKeyType
     {
-        /// <summary>RSA key.</summary>
         RSA,
 
         /// <summary>ECDSA (NIST curve) key.</summary>


### PR DESCRIPTION
Throwaway: removes one XML doc comment to confirm CS1591 fails the build on the CI SDK. Will be closed.