### PR TITLE
Silence CS1591 doc warnings from the vendored Chaos.NaCl submodule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,7 @@
 root = true
 
 # Undocumented public members are an error, so the public API stays documented.
+# (Vendored Chaos.NaCl is silenced by a CI step that drops a deeper .editorconfig next
+#  to its sources — its own root .editorconfig blocks a rule here from reaching them.)
 [*.cs]
 dotnet_diagnostic.CS1591.severity = error
-
-# Vendored submodule — not part of our documented public API.
-[Chaos.NaCl/**/*.cs]
-dotnet_diagnostic.CS1591.severity = none

--- a/.github/workflows/dotnet-ubuntu.yml
+++ b/.github/workflows/dotnet-ubuntu.yml
@@ -15,6 +15,11 @@ jobs:
     - uses: actions/checkout@v7
       with:
         submodules: recursive
+    # Chaos.NaCl ships a root=true .editorconfig that blocks our CS1591 rule; drop a
+    # deeper one so its vendored sources don't trip the documented-API check.
+    - name: Exempt vendored Chaos.NaCl from the doc check
+      shell: bash
+      run: printf '[*.cs]\ndotnet_diagnostic.CS1591.severity = none\n' > Chaos.NaCl/Chaos.NaCl/.editorconfig
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:

--- a/.github/workflows/dotnet-windows.yml
+++ b/.github/workflows/dotnet-windows.yml
@@ -15,6 +15,11 @@ jobs:
     - uses: actions/checkout@v7
       with:
         submodules: recursive
+    # Chaos.NaCl ships a root=true .editorconfig that blocks our CS1591 rule; drop a
+    # deeper one so its vendored sources don't trip the documented-API check.
+    - name: Exempt vendored Chaos.NaCl from the doc check
+      shell: bash
+      run: printf '[*.cs]\ndotnet_diagnostic.CS1591.severity = none\n' > Chaos.NaCl/Chaos.NaCl/.editorconfig
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -19,6 +19,11 @@ jobs:
     - uses: actions/checkout@v7
       with:
         submodules: recursive
+    # Chaos.NaCl ships a root=true .editorconfig that blocks our CS1591 rule; drop a
+    # deeper one so its vendored sources don't trip the documented-API check.
+    - name: Exempt vendored Chaos.NaCl from the doc check
+      shell: bash
+      run: printf '[*.cs]\ndotnet_diagnostic.CS1591.severity = none\n' > Chaos.NaCl/Chaos.NaCl/.editorconfig
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:


### PR DESCRIPTION
Follow-up to the documented-API work (#36).

**Problem:** The Chaos.NaCl submodule ships its own `root = true` .editorconfig, which stops editorconfig resolution before it reaches our repo-root rules. So the `[Chaos.NaCl/**]` suppression in our .editorconfig was dead on every SDK, and its ~124 public-but-undocumented members surfaced as CS1591 **warnings** in CI logs. `<NoWarn>` can't be used — it outranks the editorconfig `severity = error` and would disable our own enforcement too (verified).

**Fix:** a CI step drops a *deeper* `.editorconfig` right next to the vendored sources (inside the submodule tree, so it can't be committed — hence generated in CI), setting CS1591 to `none` there. Being closer to the files, it wins for the vendored code; our own code is still enforced by the repo-root config. Removed the now-dead `[Chaos.NaCl/**]` section.

**Verified locally** (simulating the CI step): lib + test builds produce 0 CS1591 and 0 CS8700; removing any doc comment still fails the build. And I confirmed on CI earlier that our-code enforcement genuinely errors on the 8.0 SDK (a throwaway PR with a missing doc failed with `error CS1591`).