### PR TITLE
Replace obsolete RNGCryptoServiceProvider with RandomNumberGenerator

### DIFF
--- a/SshNet.Keygen/SshKey.cs
+++ b/SshNet.Keygen/SshKey.cs
@@ -68,7 +68,7 @@ namespace SshNet.Keygen
             {
                 case SshKeyType.ED25519:
                 {
-                    using var rngCsp = new RNGCryptoServiceProvider();
+                    using var rngCsp = RandomNumberGenerator.Create();
                     var seed = new byte[Ed25519.PrivateKeySeedSizeInBytes];
                     rngCsp.GetBytes(seed);
                     Ed25519.KeyPairFromSeed(out _, out var edKey, seed);

--- a/SshNet.Keygen/SshKeyEncryption/SshKeyEncryptionAes256.cs
+++ b/SshNet.Keygen/SshKeyEncryption/SshKeyEncryptionAes256.cs
@@ -73,7 +73,7 @@ namespace SshNet.Keygen.SshKeyEncryption
         {
             using var stream = new MemoryStream();
             using var writer = new BinaryWriter(stream);
-            using var rng = new RNGCryptoServiceProvider();
+            using var rng = RandomNumberGenerator.Create();
             rng.GetBytes(_salt);
             writer.EncodeBinary(_salt);
             writer.EncodeUInt(Rounds);
@@ -172,7 +172,7 @@ namespace SshNet.Keygen.SshKeyEncryption
             argon2.MemorySize = _puttyV3Encryption.MemorySize;
             argon2.Iterations = _puttyV3Encryption.Iterations;
 
-            using var rng = new RNGCryptoServiceProvider();
+            using var rng = RandomNumberGenerator.Create();
             rng.GetBytes(_salt);
             argon2.Salt = _salt;
             _puttyV3Encryption.Salt = _salt;


### PR DESCRIPTION
`RNGCryptoServiceProvider` is obsolete on net8.0 (SYSLIB0023). Swaps the three uses (one in `SshKey`, two in `SshKeyEncryptionAes256`) for `RandomNumberGenerator.Create()`, which is the non-obsolete, cross-TFM equivalent (net48 / netstandard2.0 / net8.0) with the same `GetBytes` API — a drop-in change.

Left the vendored `Bcrypt.cs` occurrence alone: it's in the bundled bcrypt port under a `#if FEATURE_RNG_CSP` branch that isn't compiled (produces no warning).

Verified: all three TFMs build with no SYSLIB0023 from our code; 17/17 tests pass.