### PR TITLE
Encode key passphrases as UTF-8 instead of ASCII

### DIFF
--- a/SshNet.Keygen.Tests/TestKey.cs
+++ b/SshNet.Keygen.Tests/TestKey.cs
@@ -302,5 +302,18 @@ namespace SshNet.Keygen.Tests
             TestFormatKey<ED25519Key>("ED25519", 256);
             TestFormatKey<ED25519Key>("ED25519", 256, "12345");
         }
+
+        [Test]
+        public void TestNonAsciiPassphraseRoundTrips()
+        {
+            // regression: ASCII encoding mangled non-ASCII passphrases into an unusable key.
+            // OpenSSH only — SSH.NET cannot read back its own encrypted PuTTY keys; real
+            // puttygen interop covers those.
+            const string passphrase = "Paßwort-Пароль";
+            var key = SshKey.Generate(new SshKeyGenerateInfo(SshKeyType.ED25519));
+            var exported = key.ToOpenSshFormat(new SshKeyEncryptionAes256(passphrase));
+
+            Assert.DoesNotThrow((Action)(() => _ = new PrivateKeyFile(exported.ToStream(), passphrase)));
+        }
     }
 }

--- a/SshNet.Keygen/Extensions/KeyExtension.cs
+++ b/SshNet.Keygen/Extensions/KeyExtension.cs
@@ -257,7 +257,7 @@ namespace SshNet.Keygen.Extensions
                 privateBase64String = Convert.ToBase64String(encrypted).FormatNewLines(64);
 
                 using var sha1 = SHA1.Create();
-                var macKey = sha1.ComputeHash(Encoding.ASCII.GetBytes("putty-private-key-file-mac-key" + encryption.Passphrase));
+                var macKey = sha1.ComputeHash(Encoding.UTF8.GetBytes("putty-private-key-file-mac-key" + encryption.Passphrase));
                 using var hmac = new HMACSHA1(macKey);
                 macHash = hmac.ComputeHash(hashData);
             }

--- a/SshNet.Keygen/SshKeyEncryption/SshKeyEncryptionAes256.cs
+++ b/SshNet.Keygen/SshKeyEncryption/SshKeyEncryptionAes256.cs
@@ -53,7 +53,8 @@ namespace SshNet.Keygen.SshKeyEncryption
         public SshKeyEncryptionAes256(string passphrase, PuttyV3Encryption? puttyV3Encryption = null)
         {
             _passphrase = passphrase;
-            _passPhraseBytes = Encoding.ASCII.GetBytes(passphrase);
+            // UTF-8 to match OpenSSH and PuTTY 0.82+; ASCII mangled non-ASCII passphrases
+            _passPhraseBytes = Encoding.UTF8.GetBytes(passphrase);
             _salt = new byte[SaltLen];
             _puttyV3Encryption = puttyV3Encryption ?? new PuttyV3Encryption();
         }


### PR DESCRIPTION
## Problem

Passphrases were converted to bytes with `Encoding.ASCII.GetBytes`. ASCII replaces every non-ASCII character with `?`, so a key encrypted with a passphrase containing accented/non-Latin characters (e.g. `Paßwort`, `Пароль`) was encrypted under a *different* passphrase than the user typed. The result could not be decrypted by `ssh`/PuTTY, nor re-read by SSH.NET — a silent interop break for international users.

## Fix

Encode passphrases as **UTF-8** at both sites:

- `SshKeyEncryptionAes256` — the bytes fed to the bcrypt KDF (OpenSSH) and the PuTTY v2/v3 key derivation.
- `KeyExtension` — the PuTTY v2 MAC key (`putty-private-key-file-mac-key` + passphrase).

UTF-8 is what OpenSSH uses, and what PuTTY uses since 0.82 (before that, Windows PuTTY used the local codepage — never ASCII, so the old behavior was wrong for non-ASCII on every PuTTY version). For ASCII passphrases the encoded bytes are byte-for-byte identical, so **existing keys and the common case are unaffected**.

## Test

`TestNonAsciiPassphraseRoundTrips` generates an Ed25519 key encrypted with a non-ASCII passphrase and re-imports it via `PrivateKeyFile`. Verified it **fails on the old ASCII code** and **passes** with the fix. (OpenSSH only — SSH.NET cannot read back its own encrypted PuTTY keys; real `puttygen` interop is a separate follow-up.)