### PR TITLE
Add ssh-keygen and puttygen interop tests

### DIFF
--- a/.github/workflows/dotnet-ubuntu.yml
+++ b/.github/workflows/dotnet-ubuntu.yml
@@ -28,8 +28,13 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore
+    - name: Install puttygen for the interop tests (ssh-keygen is preinstalled)
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends putty-tools
     - name: Test
       run: dotnet test --no-build --verbosity normal
+      env:
+        # run the ssh-keygen/puttygen interop tests instead of skipping them
+        SSHNET_KEYGEN_INTEROP_REQUIRED: "1"
     - uses: actions/upload-artifact@v7
       with:
         name: Sample-ubuntu

--- a/SshNet.Keygen.Tests/InteropTests.cs
+++ b/SshNet.Keygen.Tests/InteropTests.cs
@@ -27,6 +27,7 @@ namespace SshNet.Keygen.Tests
             using var dir = new TempDir();
             var keyPath = Path.Combine(dir.Path, "id");
             var key = Generate(keyType, SshKeyFormat.OpenSSH, encrypted, keyPath);
+            RestrictToOwner(keyPath); // ssh-keygen refuses a world-readable private key
 
             // ssh-keygen -y derives the public key from the private key, decrypting first
             var result = Run("ssh-keygen", $"-y -P \"{(encrypted ? Passphrase : "")}\" -f \"{keyPath}\"");
@@ -69,6 +70,14 @@ namespace SshNet.Keygen.Tests
                 Encryption = encrypted ? new SshKeyEncryptionAes256(Passphrase) : new SshKeyEncryptionNone()
             };
             return SshKey.Generate(path, FileMode.Create, info);
+        }
+
+        private static void RestrictToOwner(string path)
+        {
+#if NET8_0_OR_GREATER
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+#endif
         }
 
         // "<type> <base64>" — the identifying fields of an OpenSSH public key line, ignoring the comment

--- a/SshNet.Keygen.Tests/InteropTests.cs
+++ b/SshNet.Keygen.Tests/InteropTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using NUnit.Framework;
+using SshNet.Keygen.Extensions;
+using SshNet.Keygen.SshKeyEncryption;
+
+namespace SshNet.Keygen.Tests
+{
+    // Verifies generated keys are accepted by the real OpenSSH ssh-keygen and PuTTY
+    // puttygen tools, not just re-read by SSH.NET. Skipped unless
+    // SSHNET_KEYGEN_INTEROP_REQUIRED is set (the Ubuntu CI job sets it and installs
+    // the tools), so a normal local `dotnet test` never shells out.
+    public class InteropTests
+    {
+        private const string Passphrase = "SshNetKeygenInterop1";
+
+        [Test]
+        public void SshKeygenAcceptsGeneratedKey(
+            [Values(SshKeyType.ED25519, SshKeyType.RSA, SshKeyType.ECDSA)] SshKeyType keyType,
+            [Values(false, true)] bool encrypted)
+        {
+            RequireTool("ssh-keygen");
+
+            using var dir = new TempDir();
+            var keyPath = Path.Combine(dir.Path, "id");
+            var key = Generate(keyType, SshKeyFormat.OpenSSH, encrypted, keyPath);
+
+            // ssh-keygen -y derives the public key from the private key, decrypting first
+            var result = Run("ssh-keygen", $"-y -P \"{(encrypted ? Passphrase : "")}\" -f \"{keyPath}\"");
+            Assert.That(result.Code, Is.Zero, result.Stderr);
+            Assert.That(PublicKeyId(result.Stdout), Is.EqualTo(PublicKeyId(key.ToOpenSshPublicFormat())));
+        }
+
+        [Test]
+        public void PuttygenAcceptsGeneratedKey(
+            [Values(SshKeyType.ED25519, SshKeyType.RSA, SshKeyType.ECDSA)] SshKeyType keyType,
+            [Values(SshKeyFormat.PuTTYv2, SshKeyFormat.PuTTYv3)] SshKeyFormat format,
+            [Values(false, true)] bool encrypted)
+        {
+            // the Windows puttygen is GUI-only; the CLI puttygen ships with putty-tools on Linux
+            RequireTool("puttygen", skipOnWindows: true);
+
+            using var dir = new TempDir();
+            var ppkPath = Path.Combine(dir.Path, "id.ppk");
+            var outPath = Path.Combine(dir.Path, "id.pub");
+            var key = Generate(keyType, format, encrypted, ppkPath);
+
+            var args = $"\"{ppkPath}\" -O public-openssh -o \"{outPath}\"";
+            if (encrypted)
+            {
+                var passFile = Path.Combine(dir.Path, "pass");
+                File.WriteAllText(passFile, Passphrase + "\n");
+                args += $" --old-passphrase \"{passFile}\"";
+            }
+
+            var result = Run("puttygen", args);
+            Assert.That(result.Code, Is.Zero, result.Stderr);
+            Assert.That(PublicKeyId(File.ReadAllText(outPath)), Is.EqualTo(PublicKeyId(key.ToOpenSshPublicFormat())));
+        }
+
+        private static GeneratedPrivateKey Generate(SshKeyType keyType, SshKeyFormat format, bool encrypted, string path)
+        {
+            var info = new SshKeyGenerateInfo(keyType)
+            {
+                KeyFormat = format,
+                Encryption = encrypted ? new SshKeyEncryptionAes256(Passphrase) : new SshKeyEncryptionNone()
+            };
+            return SshKey.Generate(path, FileMode.Create, info);
+        }
+
+        // "<type> <base64>" — the identifying fields of an OpenSSH public key line, ignoring the comment
+        private static string PublicKeyId(string openSshPublicKey)
+        {
+            var parts = openSshPublicKey.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            Assert.That(parts.Length, Is.GreaterThanOrEqualTo(2), $"unexpected public key: {openSshPublicKey}");
+            return $"{parts[0]} {parts[1]}";
+        }
+
+        private static void RequireTool(string exe, bool skipOnWindows = false)
+        {
+            if (Environment.GetEnvironmentVariable("SSHNET_KEYGEN_INTEROP_REQUIRED") is not { Length: > 0 })
+                Assert.Ignore("set SSHNET_KEYGEN_INTEROP_REQUIRED to run external-tool interop tests");
+            if (skipOnWindows && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                Assert.Ignore($"{exe} interop runs on non-Windows only");
+            if (!OnPath(exe))
+                Assert.Fail($"{exe} not found on PATH");
+        }
+
+        private static bool OnPath(string exe)
+        {
+            var names = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? new[] { exe + ".exe", exe + ".com", exe }
+                : new[] { exe };
+            return (Environment.GetEnvironmentVariable("PATH") ?? "")
+                .Split(Path.PathSeparator)
+                .Where(d => !string.IsNullOrEmpty(d))
+                .Any(d => names.Any(n => SafeExists(Path.Combine(d, n))));
+        }
+
+        private static bool SafeExists(string path)
+        {
+            try { return File.Exists(path); }
+            catch { return false; }
+        }
+
+        private static (int Code, string Stdout, string Stderr) Run(string exe, string args)
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = exe,
+                Arguments = args,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = Process.Start(psi);
+            var stdout = process.StandardOutput.ReadToEndAsync();
+            var stderr = process.StandardError.ReadToEndAsync();
+            if (!process.WaitForExit(30000))
+            {
+                try { process.Kill(); } catch { /* already gone */ }
+                Assert.Fail($"{exe} did not exit within 30s");
+            }
+            return (process.ExitCode, stdout.GetAwaiter().GetResult(), stderr.GetAwaiter().GetResult());
+        }
+
+        private sealed class TempDir : IDisposable
+        {
+            public string Path { get; }
+
+            public TempDir()
+            {
+                Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "sshnet-keygen-interop", Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(Path);
+            }
+
+            public void Dispose()
+            {
+                try { Directory.Delete(Path, true); } catch { /* best effort */ }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Why

The existing tests only re-read generated keys through SSH.NET's own parser. That never proved the output is accepted by the tools the library actually targets — and SSH.NET can't even read back its own encrypted PuTTY keys, so the entire PuTTY export path had **no** round-trip coverage. This is exactly the gap where a passphrase-encoding or format bug hides.

## What

`InteropTests` runs generated keys through the real external tools and compares the derived OpenSSH public key against the library's own:

- **ssh-keygen** — `ssh-keygen -y -P <pass> -f <key>` for OpenSSH keys (Ed25519 / RSA / ECDSA, encrypted + unencrypted).
- **puttygen** — `puttygen <key.ppk> -O public-openssh -o <out> [--old-passphrase <file>]` for PuTTY v2 + v3 (same key types, encrypted + unencrypted).

Gated behind `SSHNET_KEYGEN_INTEROP_REQUIRED` so a normal local `dotnet test` never shells out. The Ubuntu CI job installs `putty-tools` (`ssh-keygen` is preinstalled) and sets the switch, so the checks can't silently no-op. puttygen interop skips on Windows, where the shipped build is GUI-only.

## Validation

- ssh-keygen path: all 6 combinations pass locally.
- puttygen path: all 12 combinations (3 key types × v2/v3 × encrypted/plain) verified against real `putty-tools` 0.81 — the version ubuntu-latest ships — using the exact CLI the test issues.

Scope note: passphrases here are ASCII (version-independent). Non-ASCII passphrase correctness is covered by the unit test in #46.