### PR TITLE
Document SshKeyEncryptionAes256 thread-safety; cover instance reuse

### DIFF
--- a/SshNet.Keygen.Tests/TestKey.cs
+++ b/SshNet.Keygen.Tests/TestKey.cs
@@ -302,5 +302,22 @@ namespace SshNet.Keygen.Tests
             TestFormatKey<ED25519Key>("ED25519", 256);
             TestFormatKey<ED25519Key>("ED25519", 256, "12345");
         }
+
+        [Test]
+        public void TestEncryptionInstanceReuseAcrossExports()
+        {
+            // one instance is safe to reuse for sequential exports: each gets a fresh
+            // salt, so the outputs differ and both still decrypt
+            const string password = "12345";
+            var encryption = new SshKeyEncryptionAes256(password);
+            var key = SshKey.Generate(new SshKeyGenerateInfo(SshKeyType.ED25519));
+
+            var first = key.ToOpenSshFormat(encryption);
+            var second = key.ToOpenSshFormat(encryption);
+
+            ClassicAssert.AreNotEqual(first, second);
+            Assert.DoesNotThrow((Action)(() => _ = new PrivateKeyFile(first.ToStream(), password)));
+            Assert.DoesNotThrow((Action)(() => _ = new PrivateKeyFile(second.ToStream(), password)));
+        }
     }
 }

--- a/SshNet.Keygen/SshKeyEncryption/SshKeyEncryptionAes256.cs
+++ b/SshNet.Keygen/SshKeyEncryption/SshKeyEncryptionAes256.cs
@@ -26,6 +26,11 @@ namespace SshNet.Keygen.SshKeyEncryption
     /// <summary>
     /// Encrypts a key with AES-256 (bcrypt KDF for OpenSSH, Argon2 for PuTTY v3).
     /// </summary>
+    /// <remarks>
+    /// Each export writes scratch state (the KDF salt, and the PuTTY v3 MAC key) onto the
+    /// instance, so it is not thread-safe: use a separate instance per concurrent export.
+    /// Reusing an instance for sequential exports is fine — a fresh salt is generated each time.
+    /// </remarks>
     public class SshKeyEncryptionAes256 : ISshKeyEncryption
     {
         /// <inheritdoc />


### PR DESCRIPTION
## Context

While reviewing the encryption helper I checked the concern that reusing an `SshKeyEncryptionAes256` instance corrupts output. It turns out **sequential reuse is fine and already exercised** by the existing tests: every export calls `KdfOptions()` (OpenSSH) or `PuttyV3Encrypt()` (PuTTY v3), each of which generates a **fresh salt**, so back-to-back exports produce independent, decryptable keys.

The real, undocumented caveat is **thread-safety**: the per-export scratch state (KDF salt, PuTTY v3 MAC key) lives on the instance, so sharing one instance across *concurrent* exports races.

## Change

- Add `<remarks>` to `SshKeyEncryptionAes256` stating it is not thread-safe (use one instance per concurrent export) and that sequential reuse is safe.
- Add `TestEncryptionInstanceReuseAcrossExports`: reuses one instance for two OpenSSH exports, asserts the outputs differ (proving the fresh salt) and that both round-trip through `PrivateKeyFile`.

No API or behavior change — documentation plus a regression guard for the reuse contract.