### PR TITLE
Also test against the latest SSH.NET in CI

### DIFF
--- a/.github/workflows/dotnet-ubuntu.yml
+++ b/.github/workflows/dotnet-ubuntu.yml
@@ -35,6 +35,10 @@ jobs:
       env:
         # run the ssh-keygen/puttygen interop tests instead of skipping them
         SSHNET_KEYGEN_INTEROP_REQUIRED: "1"
+    - name: Test against the latest SSH.NET
+      run: dotnet test --verbosity normal -p:SshNetVersion=2025.1.0
+      env:
+        SSHNET_KEYGEN_INTEROP_REQUIRED: "1"
     - uses: actions/upload-artifact@v7
       with:
         name: Sample-ubuntu

--- a/SshNet.Keygen.Tests/SshNet.Keygen.Tests.csproj
+++ b/SshNet.Keygen.Tests/SshNet.Keygen.Tests.csproj
@@ -17,6 +17,13 @@
       <ProjectReference Include="..\SshNet.Keygen\SshNet.Keygen.csproj" />
     </ItemGroup>
 
+    <!-- A plain restore resolves the floor of the library's SSH.NET range; CI runs a
+         second leg with -p:SshNetVersion=<current> so the tests also exercise the
+         latest SSH.NET (e.g. its PuTTY-key reader, which the floor could not do). -->
+    <ItemGroup Condition="'$(SshNetVersion)' != ''">
+        <PackageReference Include="SSH.NET" Version="[$(SshNetVersion)]" />
+    </ItemGroup>
+
     <ItemGroup>
       <EmbeddedResource Include="TestKeys\*" />
     </ItemGroup>

--- a/SshNet.Keygen.Tests/SshNetReadTests.cs
+++ b/SshNet.Keygen.Tests/SshNetReadTests.cs
@@ -1,0 +1,45 @@
+using System;
+using NUnit.Framework;
+using Renci.SshNet;
+using SshNet.Keygen.Extensions;
+using SshNet.Keygen.SshKeyEncryption;
+
+namespace SshNet.Keygen.Tests
+{
+    // Round-trips every generated key format back through SSH.NET's own parser.
+    // SSH.NET could not read PuTTY keys until after 2024.2.0 (the library's range
+    // floor), so those cases run only when a new enough SSH.NET is resolved - the
+    // -p:SshNetVersion CI leg. OpenSSH round-trips on every supported version.
+    public class SshNetReadTests
+    {
+        private static readonly Version LoadedSshNet =
+            typeof(PrivateKeyFile).Assembly.GetName().Version ?? new Version();
+        private static readonly Version PuttyReadable = new(2025, 1, 0);
+
+        [Test]
+        public void SshNetReadsGeneratedKey(
+            [Values(SshKeyType.ED25519, SshKeyType.RSA, SshKeyType.ECDSA)] SshKeyType keyType,
+            [Values(SshKeyFormat.OpenSSH, SshKeyFormat.PuTTYv2, SshKeyFormat.PuTTYv3)] SshKeyFormat format,
+            [Values(false, true)] bool encrypted)
+        {
+            var isPutty = format is SshKeyFormat.PuTTYv2 or SshKeyFormat.PuTTYv3;
+            if (isPutty && LoadedSshNet < PuttyReadable)
+                Assert.Ignore($"SSH.NET {LoadedSshNet} cannot read PuTTY keys; needs >= {PuttyReadable}");
+
+            const string password = "12345";
+            var info = new SshKeyGenerateInfo(keyType)
+            {
+                KeyFormat = format,
+                Encryption = encrypted ? new SshKeyEncryptionAes256(password) : new SshKeyEncryptionNone()
+            };
+
+            var key = SshKey.Generate(info);
+            var exported = format == SshKeyFormat.OpenSSH
+                ? key.ToOpenSshFormat(info.Encryption)
+                : key.ToPuttyFormat(info.Encryption, format);
+
+            Assert.DoesNotThrow((Action)(() =>
+                _ = new PrivateKeyFile(exported.ToStream(), encrypted ? password : null)));
+        }
+    }
+}


### PR DESCRIPTION
## Why

The library declares `SSH.NET` as `[2024.2.0,2026.0)`, and a plain `dotnet restore` resolves the **floor** (2024.2.0). So the test suite only ever exercised the oldest supported SSH.NET — never current releases. That matters: e.g. 2024.2.0 cannot read back an encrypted PuTTY private key, but 2025.1.0 can. Behavior the tests depend on can differ across the supported range, and we were blind to it.

## What

Mirrors the mechanism `SshNet.Agent` already uses (`-p:SshNetVersion=…`):

- Test project gains an override hook — `SSH.NET` is pinned to `[$(SshNetVersion)]` only when that property is set; a normal restore is unchanged (floor).
- The Ubuntu workflow runs a second test leg with `-p:SshNetVersion=2025.1.0`, so every push exercises the suite against both the floor and the current latest.

The shipped dependency range is unchanged. Bump the `2025.1.0` pin when a newer SSH.NET ships (same as the floor pin in the Agent repo).

## Verified

Locally, `-p:SshNetVersion=2025.1.0` resolves SSH.NET 2025.1.0 (confirmed via `project.assets.json`) and the suite passes against it.

Note: pairs naturally with #47 — once both land, the interop leg will also run against latest (minor workflow merge to combine the steps).