### PR TITLE
Prepare the 2024.2.0.3 release

### DIFF
--- a/SshNet.Keygen/SshNet.Keygen.csproj
+++ b/SshNet.Keygen/SshNet.Keygen.csproj
@@ -7,7 +7,7 @@
         <!-- docs enforced via .editorconfig (CS1591 = error for our code, none for vendored) -->
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageId>SshNet.Keygen</PackageId>
-        <Version>2024.2.0.2</Version>
+        <Version>2024.2.0.3</Version>
         <PackageVersion>$(Version)</PackageVersion>
         <PackageTags>ssh;scp;sftp</PackageTags>
         <Description>SSH.NET Extension to generate and export Authentication Keys in OpenSSH and PuTTY Format.</Description>


### PR DESCRIPTION
Bumps `SshNet.Keygen` from **2024.2.0.2** to **2024.2.0.3**. Merging triggers the NuGet workflow to publish and tag.

## Changelog since 2024.2.0.2

### Features
- Fluent `SshKey.Builder()` API — chainable alternative to `SshKeyGenerateInfo` (in-memory / `Stream` / file)

### Fixes
- **Passphrases are now encoded as UTF-8** (were ASCII, which silently mangled non-ASCII passphrases into keys `ssh`/PuTTY could not decrypt)

### Testing / CI
- Interop tests running generated keys through the real `ssh-keygen` and `puttygen` tools
- Second CI leg testing against the **latest SSH.NET** (not just the dependency-range floor), plus a round-trip test proving SSH.NET reads every generated format
- Replaced obsolete `RNGCryptoServiceProvider` with `RandomNumberGenerator`

### Dependencies
- `System.Formats.Asn1` 8.0.2 → 10.0.10 (GHSA-447r-wph3-92pm) and other minor/patch bumps