### PR TITLE
Document the net8.0 target in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ SshNet.Keygen
 
 * .NET 4.8
 * netstandard 2.0
+* .NET 8.0
 
 ## Keys
 * ssh-ed25519


### PR DESCRIPTION
The README's "## .NET Frameworks" section listed only .NET 4.8 and netstandard 2.0, but the package has shipped a `net8.0` target since 2024.2.0.2 (see the csproj `TargetFrameworks`). Add it to the list. Docs-only.