### PR TITLE
Use RandomNumberGenerator for the OpenSSH check-int

### DIFF
--- a/SshNet.Keygen/Extensions/KeyExtension.cs
+++ b/SshNet.Keygen/Extensions/KeyExtension.cs
@@ -103,7 +103,10 @@ namespace SshNet.Keygen.Extensions
             using var privStream = new MemoryStream();
             using var privWriter = new BinaryWriter(privStream);
 
-            var rnd = new Random().Next(0, int.MaxValue);
+            var checkBytes = new byte[4];
+            using (var rng = RandomNumberGenerator.Create())
+                rng.GetBytes(checkBytes);
+            var rnd = BitConverter.ToInt32(checkBytes, 0);
             privWriter.EncodeInt(rnd); // check-int1
             privWriter.EncodeInt(rnd); // check-int2
             privWriter.EncodeBinary(key.ToString()!);


### PR DESCRIPTION
The OpenSSH private-key blob carries a check-int written twice; a correct decrypt is confirmed when the two copies match, so the value itself isn't security-critical. Still, `new Random()` ([KeyExtension.cs](SshNet.Keygen/SshNet.Keygen/Extensions/KeyExtension.cs)) is analyzer-flagged and clock-seeded — swap it for `RandomNumberGenerator`, which is already used in this file.

Behavior is unchanged (both check-ints remain equal); the existing OpenSSH round-trip tests, which re-parse the generated key via `PrivateKeyFile`, cover it.