### PR TITLE
Replace vendored Chaos.NaCl with SSH.NET's ED25519Key

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,0 @@
-root = true
-
-# Undocumented public members are an error, so the public API stays documented.
-# (Vendored Chaos.NaCl is silenced by a CI step that drops a deeper .editorconfig next
-#  to its sources — its own root .editorconfig blocks a rule here from reaching them.)
-[*.cs]
-dotnet_diagnostic.CS1591.severity = error

--- a/.github/workflows/dotnet-ubuntu.yml
+++ b/.github/workflows/dotnet-ubuntu.yml
@@ -13,13 +13,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
-      with:
-        submodules: recursive
-    # Chaos.NaCl ships a root=true .editorconfig that blocks our CS1591 rule; drop a
-    # deeper one so its vendored sources don't trip the documented-API check.
-    - name: Exempt vendored Chaos.NaCl from the doc check
-      shell: bash
-      run: printf '[*.cs]\ndotnet_diagnostic.CS1591.severity = none\n' > Chaos.NaCl/Chaos.NaCl/.editorconfig
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:

--- a/.github/workflows/dotnet-windows.yml
+++ b/.github/workflows/dotnet-windows.yml
@@ -13,13 +13,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
-      with:
-        submodules: recursive
-    # Chaos.NaCl ships a root=true .editorconfig that blocks our CS1591 rule; drop a
-    # deeper one so its vendored sources don't trip the documented-API check.
-    - name: Exempt vendored Chaos.NaCl from the doc check
-      shell: bash
-      run: printf '[*.cs]\ndotnet_diagnostic.CS1591.severity = none\n' > Chaos.NaCl/Chaos.NaCl/.editorconfig
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -17,13 +17,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
-      with:
-        submodules: recursive
-    # Chaos.NaCl ships a root=true .editorconfig that blocks our CS1591 rule; drop a
-    # deeper one so its vendored sources don't trip the documented-API check.
-    - name: Exempt vendored Chaos.NaCl from the doc check
-      shell: bash
-      run: printf '[*.cs]\ndotnet_diagnostic.CS1591.severity = none\n' > Chaos.NaCl/Chaos.NaCl/.editorconfig
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Chaos.NaCl"]
-	path = Chaos.NaCl
-	url = https://github.com/CodesInChaos/Chaos.NaCl

--- a/SshNet.Keygen/SshKey.cs
+++ b/SshNet.Keygen/SshKey.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Security.Cryptography;
-using Chaos.NaCl;
 using Renci.SshNet.Security;
 using SshNet.Keygen.Extensions;
 
@@ -75,11 +74,11 @@ namespace SshNet.Keygen
             {
                 case SshKeyType.ED25519:
                 {
+                    // SSH.NET's ED25519Key takes the 32-byte RFC 8032 seed and derives the public key.
                     using var rngCsp = RandomNumberGenerator.Create();
-                    var seed = new byte[Ed25519.PrivateKeySeedSizeInBytes];
+                    var seed = new byte[32];
                     rngCsp.GetBytes(seed);
-                    Ed25519.KeyPairFromSeed(out _, out var edKey, seed);
-                    key = new ED25519Key(edKey.Reverse());
+                    key = new ED25519Key(seed);
                     break;
                 }
                 case SshKeyType.RSA:

--- a/SshNet.Keygen/SshNet.Keygen.csproj
+++ b/SshNet.Keygen/SshNet.Keygen.csproj
@@ -4,8 +4,8 @@
         <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;net8.0</TargetFrameworks>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
-        <!-- docs enforced via .editorconfig (CS1591 = error for our code, none for vendored) -->
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <WarningsAsErrors>CS1591</WarningsAsErrors>
         <PackageId>SshNet.Keygen</PackageId>
         <Version>2024.2.0.3</Version>
         <PackageVersion>$(Version)</PackageVersion>
@@ -41,10 +41,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Compile Include="..\Chaos.NaCl\Chaos.NaCl\**\*.cs" Exclude="..\Chaos.NaCl\Chaos.NaCl\Properties\*">
-            <Link>Chaos.Nacl\%(RecursiveDir)%(Filename)%(Extension)</Link>
-        </Compile>
-
         <PackageReference Include="SSH.NET" Version="[2024.2.0,2026.0)" />
         <PackageReference Include="Konscious.Security.Cryptography.Argon2" Version="1.3.1"/>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="All" />


### PR DESCRIPTION
## What

Removes the vendored `Chaos.NaCl` submodule and generates Ed25519 keys with SSH.NET's own `ED25519Key` instead.

## Why

Chaos.NaCl was a git submodule compiled directly into the package purely to produce an Ed25519 key pair. SSH.NET already ships `ED25519Key`, which takes the 32-byte RFC 8032 seed and derives the public key itself — so the whole dependency was redundant.

## Changes

- `SshKey.cs`: feed a 32-byte seed straight to `new ED25519Key(seed)`; drop the Chaos.NaCl `KeyPairFromSeed` + reverse dance.
- Remove the `Chaos.NaCl` submodule and `.gitmodules`, and the `<Compile Include>` of its sources from the csproj.
- Drop the `submodules: recursive` checkout and the Chaos.NaCl doc-exemption step from all three workflows.
- Doc enforcement (CS1591) moves from the standalone `.editorconfig` to `<WarningsAsErrors>CS1591</WarningsAsErrors>` in the csproj — the separate file only existed to exempt the vendored sources.

## Verification

- `SshNetReadsGeneratedKey(ED25519, OpenSSH, …)` passes: SSH.NET re-parses the generated key, confirming the derived public key is correct and the encrypted round-trip works.
- Confirmed an undocumented public member still fails the build, so the CS1591 policy carries over intact.