### PR TITLE
Add .NET key interop (FromKey / PEM / PKCS#8 import)

### DIFF
--- a/SshNet.Keygen.Tests/ExternalTool.cs
+++ b/SshNet.Keygen.Tests/ExternalTool.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace SshNet.Keygen.Tests
+{
+    // Minimal helper to shell out to OpenSSH tools (ssh-keygen) for real-world verification.
+    // Unlike InteropTests this is not env-gated: callers skip gracefully when the tool is absent.
+    internal static class ExternalTool
+    {
+        public static bool OnPath(string exe)
+        {
+            var names = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? new[] { exe + ".exe", exe + ".com", exe }
+                : new[] { exe };
+            return (Environment.GetEnvironmentVariable("PATH") ?? "")
+                .Split(Path.PathSeparator)
+                .Where(d => !string.IsNullOrEmpty(d))
+                .Any(d => names.Any(n => SafeExists(Path.Combine(d, n))));
+        }
+
+        private static bool SafeExists(string path)
+        {
+            try { return File.Exists(path); }
+            catch { return false; }
+        }
+
+        public static (int Code, string Stdout, string Stderr) Run(string exe, string args)
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = exe,
+                Arguments = args,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = Process.Start(psi);
+            var stdout = process!.StandardOutput.ReadToEndAsync();
+            var stderr = process.StandardError.ReadToEndAsync();
+            if (!process.WaitForExit(30000))
+            {
+                try { process.Kill(); } catch { /* already gone */ }
+                throw new TimeoutException($"{exe} did not exit within 30s");
+            }
+            return (process.ExitCode, stdout.GetAwaiter().GetResult(), stderr.GetAwaiter().GetResult());
+        }
+
+        public static void RestrictToOwner(string path)
+        {
+#if NET8_0_OR_GREATER
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+#endif
+        }
+
+        public sealed class TempDir : IDisposable
+        {
+            public string Path { get; }
+
+            public TempDir()
+            {
+                Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "sshnet-keygen-tests", Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(Path);
+            }
+
+            public void Dispose()
+            {
+                try { Directory.Delete(Path, true); } catch { /* best effort */ }
+            }
+        }
+    }
+}

--- a/SshNet.Keygen.Tests/KeyInteropTests.cs
+++ b/SshNet.Keygen.Tests/KeyInteropTests.cs
@@ -1,0 +1,163 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using Renci.SshNet;
+using Renci.SshNet.Security;
+using SshNet.Keygen.Extensions;
+
+namespace SshNet.Keygen.Tests
+{
+    // Bridges BCL keys / PEM into SSH.NET keys and back. Correctness is proven three ways:
+    // an SSH.NET round-trip, an RSA signature verified against the original BCL key, and
+    // (when present) ssh-keygen parsing the exported public key.
+    public class KeyInteropTests
+    {
+        // "<type> <base64>" of an OpenSSH public key line, ignoring the comment
+        private static string PublicId(string openSshPublicKey)
+        {
+            var parts = openSshPublicKey.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            Assert.That(parts.Length, Is.GreaterThanOrEqualTo(2), $"unexpected public key: {openSshPublicKey}");
+            return $"{parts[0]} {parts[1]}";
+        }
+
+        // cryptographic part of the fingerprint (e.g. "SHA256:..."), ignoring the comment SSH.NET's reader drops
+        private static string FpHash(IPrivateKeySource key)
+        {
+            return key.Fingerprint().Split(' ').First(t => t.Contains(':'));
+        }
+
+        private static void AssertRoundTrips(GeneratedPrivateKey gen)
+        {
+            var reloaded = new PrivateKeyFile(gen.ToOpenSshFormat().ToStream());
+            ClassicAssert.AreEqual(FpHash(gen), FpHash(reloaded));
+            ClassicAssert.AreEqual(PublicId(gen.ToOpenSshPublicFormat()), PublicId(reloaded.ToPublic()));
+            SshKeygenParsesPublic(gen);
+        }
+
+        // "cross-check the exported public key parses" - skipped gracefully if ssh-keygen is absent
+        private static void SshKeygenParsesPublic(GeneratedPrivateKey gen)
+        {
+            if (!ExternalTool.OnPath("ssh-keygen"))
+                return;
+
+            using var dir = new ExternalTool.TempDir();
+            var pub = Path.Combine(dir.Path, "id.pub");
+            File.WriteAllText(pub, gen.ToOpenSshPublicFormat());
+            var r = ExternalTool.Run("ssh-keygen", $"-l -f \"{pub}\"");
+            Assert.That(r.Code, Is.Zero, r.Stderr);
+        }
+
+        [Test]
+        public void FromRsaKeyRoundTrips()
+        {
+            using var rsa = RSA.Create(2048);
+            var gen = SshKey.FromKey(rsa, "rsa@interop");
+
+            ClassicAssert.IsInstanceOf<RsaKey>(((KeyHostAlgorithm)gen.HostKeyAlgorithms.First()).Key);
+            AssertRoundTrips(gen);
+
+            // deterministic: same input imports to the same key, a different input to a different key
+            ClassicAssert.AreEqual(FpHash(gen), FpHash(SshKey.FromKey(rsa)));
+            using var other = RSA.Create(2048);
+            ClassicAssert.AreNotEqual(FpHash(gen), FpHash(SshKey.FromKey(other)));
+        }
+
+        [Test]
+        public void FromRsaKeyImportsPrivateKey()
+        {
+            // definitive: a signature made by the imported SSH key verifies against the original BCL key
+            using var rsa = RSA.Create(2048);
+            var gen = SshKey.FromKey(rsa);
+            var data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+            var alg = gen.HostKeyAlgorithms.Cast<KeyHostAlgorithm>().First(h => h.Name == "rsa-sha2-256");
+            var sig = SecondSshString(alg.Sign(data)); // blob = string alg, string signature
+
+            ClassicAssert.IsTrue(rsa.VerifyData(data, sig, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1));
+        }
+
+        [Test]
+        public void FromEcdsaKeyRoundTrips([Values(256, 384, 521)] int keySize)
+        {
+            using var ecdsa = ECDsa.Create(ECCurve.CreateFromFriendlyName($"nistp{keySize}"));
+            var gen = SshKey.FromKey(ecdsa, "ecdsa@interop");
+
+            ClassicAssert.IsInstanceOf<EcdsaKey>(((KeyHostAlgorithm)gen.HostKeyAlgorithms.First()).Key);
+            ClassicAssert.AreEqual(keySize, ((KeyHostAlgorithm)gen.HostKeyAlgorithms.First()).Key.KeyLength);
+            AssertRoundTrips(gen);
+        }
+
+        [Test]
+        public void FromEd25519RoundTrips()
+        {
+            var seed = new byte[32];
+            using (var rng = RandomNumberGenerator.Create())
+                rng.GetBytes(seed);
+
+            var gen = SshKey.FromEd25519(seed, "ed25519@interop");
+            ClassicAssert.IsInstanceOf<ED25519Key>(((KeyHostAlgorithm)gen.HostKeyAlgorithms.First()).Key);
+            AssertRoundTrips(gen);
+
+            // a 64-byte expanded key (seed || public) yields the same key as its 32-byte seed
+            var ed = (ED25519Key)((KeyHostAlgorithm)gen.HostKeyAlgorithms.First()).Key;
+            var expanded = new byte[64];
+            Buffer.BlockCopy(seed, 0, expanded, 0, 32);
+            Buffer.BlockCopy(ed.PublicKey, 0, expanded, 32, 32);
+            ClassicAssert.AreEqual(FpHash(gen), FpHash(SshKey.FromEd25519(expanded)));
+        }
+
+        [Test]
+        public void FromEd25519RejectsBadInput()
+        {
+            Assert.Throws<ArgumentNullException>((Action)(() => SshKey.FromEd25519(null!)));
+            Assert.Throws<ArgumentException>((Action)(() => SshKey.FromEd25519(new byte[16])));
+        }
+
+#if NET8_0_OR_GREATER
+        [Test]
+        public void FromPemImportsRsa()
+        {
+            using var rsa = RSA.Create(2048);
+            var expected = FpHash(SshKey.FromKey(rsa));
+
+            ClassicAssert.AreEqual(expected, FpHash(SshKey.FromPem(rsa.ExportPkcs8PrivateKeyPem())));
+            ClassicAssert.AreEqual(expected, FpHash(SshKey.FromPem(rsa.ExportRSAPrivateKeyPem())));
+
+            var pbe = new PbeParameters(PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA256, 100_000);
+            var enc = rsa.ExportEncryptedPkcs8PrivateKeyPem("s3cret", pbe);
+            ClassicAssert.AreEqual(expected, FpHash(SshKey.FromPem(enc, "s3cret")));
+            Assert.Throws<CryptographicException>((Action)(() => SshKey.FromPem(enc, "wrong")));
+        }
+
+        [Test]
+        public void FromPemImportsEcdsa()
+        {
+            using var ecdsa = ECDsa.Create(ECCurve.CreateFromFriendlyName("nistp256"));
+            var expected = FpHash(SshKey.FromKey(ecdsa));
+
+            ClassicAssert.AreEqual(expected, FpHash(SshKey.FromPem(ecdsa.ExportPkcs8PrivateKeyPem())));
+            ClassicAssert.AreEqual(expected, FpHash(SshKey.FromPem(ecdsa.ExportECPrivateKeyPem())));
+        }
+#else
+        [Test]
+        public void FromPemNotSupportedOnOldTfm()
+        {
+            Assert.Throws<PlatformNotSupportedException>((Action)(() => SshKey.FromPem("-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----")));
+        }
+#endif
+
+        // second length-prefixed SSH string of a signature blob (string alg, string signature)
+        private static byte[] SecondSshString(byte[] blob)
+        {
+            var len1 = (blob[0] << 24) | (blob[1] << 16) | (blob[2] << 8) | blob[3];
+            var off = 4 + len1;
+            var len2 = (blob[off] << 24) | (blob[off + 1] << 16) | (blob[off + 2] << 8) | blob[off + 3];
+            var sig = new byte[len2];
+            Buffer.BlockCopy(blob, off + 4, sig, 0, len2);
+            return sig;
+        }
+    }
+}

--- a/SshNet.Keygen/Extensions/EcdsaExtension.cs
+++ b/SshNet.Keygen/Extensions/EcdsaExtension.cs
@@ -14,7 +14,6 @@ namespace SshNet.Keygen.Extensions
             return q;
         }
 
-#if NETSTANDARD
         // EcParameters.Curve.Oid.FriendlyName returns different values if OpenSSL or Windows-Crypto
         public static string EcCurveNameSshCompat(this ECDsa ecdsa)
         {
@@ -33,7 +32,8 @@ namespace SshNet.Keygen.Extensions
             var qy = ecdsaParameters.Q.Y!;
             return UncompressedCoords(qx, qy);
         }
-#else
+
+#if !NETSTANDARD
         public enum KeyBlobMagicNumber
         {
             BCRYPT_ECDSA_PRIVATE_P256_MAGIC = 0x32534345,

--- a/SshNet.Keygen/SshKey.cs
+++ b/SshNet.Keygen/SshKey.cs
@@ -84,16 +84,7 @@ namespace SshNet.Keygen
                 case SshKeyType.RSA:
                 {
                     using var rsa = CreateRSA(info.KeyLength);
-                    var rsaParameters = rsa.ExportParameters(true);
-
-                    key = new RsaKey(
-                        rsaParameters.Modulus!.ToBigInteger2().ToByteArray().Reverse().ToBigInteger(),
-                        rsaParameters.Exponent!.ToBigInteger2().ToByteArray().Reverse().ToBigInteger(),
-                        rsaParameters.D!.ToBigInteger2().ToByteArray().Reverse().ToBigInteger(),
-                        rsaParameters.P!.ToBigInteger2().ToByteArray().Reverse().ToBigInteger(),
-                        rsaParameters.Q!.ToBigInteger2().ToByteArray().Reverse().ToBigInteger(),
-                        rsaParameters.InverseQ!.ToBigInteger2().ToByteArray().Reverse().ToBigInteger()
-                    );
+                    key = ToRsaKey(rsa.ExportParameters(true));
                     break;
                 }
                 case SshKeyType.ECDSA:
@@ -143,6 +134,105 @@ namespace SshNet.Keygen
 
             key.Comment = info.Comment;
             return new GeneratedPrivateKey(key, info);
+        }
+
+        /// <summary>Wraps an existing <see cref="RSA"/> key as an SSH.NET key.</summary>
+        /// <param name="rsa">The RSA key (must be exportable, including the private key).</param>
+        /// <param name="comment">Optional key comment.</param>
+        public static GeneratedPrivateKey FromKey(RSA rsa, string? comment = null)
+        {
+            var key = ToRsaKey(rsa.ExportParameters(true));
+            key.Comment = comment ?? "";
+            return new GeneratedPrivateKey(key, new SshKeyGenerateInfo(SshKeyType.RSA));
+        }
+
+        /// <summary>Wraps an existing <see cref="ECDsa"/> key as an SSH.NET key.</summary>
+        /// <param name="ecdsa">The ECDSA key (must be exportable, including the private key).</param>
+        /// <param name="comment">Optional key comment.</param>
+        public static GeneratedPrivateKey FromKey(ECDsa ecdsa, string? comment = null)
+        {
+            var p = ecdsa.ExportParameters(true);
+            var key = new EcdsaKey(ecdsa.EcCurveNameSshCompat(), p.UncompressedCoords(), p.D!);
+            key.Comment = comment ?? "";
+            return new GeneratedPrivateKey(key, new SshKeyGenerateInfo(SshKeyType.ECDSA));
+        }
+
+        /// <summary>Wraps an Ed25519 key given its raw 32-byte seed or 64-byte expanded (seed+public) key.</summary>
+        /// <param name="key">32-byte RFC 8032 seed, or 64-byte OpenSSH expanded private key.</param>
+        /// <param name="comment">Optional key comment.</param>
+        public static GeneratedPrivateKey FromEd25519(byte[] key, string? comment = null)
+        {
+            if (key is null)
+                throw new ArgumentNullException(nameof(key));
+
+            var seed = new byte[32];
+            switch (key.Length)
+            {
+                case 32:
+                case 64: // seed || public
+                    Buffer.BlockCopy(key, 0, seed, 0, 32);
+                    break;
+                default:
+                    throw new ArgumentException("Ed25519 key must be a 32-byte seed or 64-byte expanded key.", nameof(key));
+            }
+
+            var ed = new ED25519Key(seed) { Comment = comment ?? "" };
+            return new GeneratedPrivateKey(ed, new SshKeyGenerateInfo(SshKeyType.ED25519));
+        }
+
+#if NET8_0_OR_GREATER
+        /// <summary>Imports an RSA or ECDSA private key from a PEM (PKCS#1, SEC1 or PKCS#8, optionally encrypted).</summary>
+        /// <param name="pem">The PEM text.</param>
+        /// <param name="passphrase">Passphrase for an encrypted PKCS#8 PEM, or null.</param>
+        public static GeneratedPrivateKey FromPem(string pem, string? passphrase = null)
+        {
+            using var rsa = RSA.Create();
+            if (TryImportPem(rsa, pem, passphrase))
+                return FromKey(rsa);
+
+            using var ecdsa = ECDsa.Create();
+            if (TryImportPem(ecdsa, pem, passphrase))
+                return FromKey(ecdsa);
+
+            throw new CryptographicException("Could not import PEM as an RSA or ECDSA private key (wrong passphrase or unsupported key).");
+        }
+
+        private static bool TryImportPem(AsymmetricAlgorithm alg, string pem, string? passphrase)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(passphrase))
+                    alg.ImportFromPem(pem);
+                else
+                    alg.ImportFromEncryptedPem(pem, passphrase);
+                return true;
+            }
+            catch (ArgumentException) { return false; }      // no matching PEM label for this algorithm
+            catch (CryptographicException) { return false; } // wrong algorithm or passphrase
+        }
+#else
+        // ponytail: netstandard2.0/net48 BCL has no ImportFromPem; a hand-rolled ASN.1 PKCS#8 parser
+        // is well over the ~40 line ceiling, so PEM import is net8.0-only. Upgrade path: port the parser
+        // via System.Formats.Asn1 (already referenced) if older TFMs ever need it.
+        /// <summary>PEM import is only available on .NET 8 or later.</summary>
+        /// <param name="pem">The PEM text.</param>
+        /// <param name="passphrase">Passphrase for an encrypted PKCS#8 PEM, or null.</param>
+        public static GeneratedPrivateKey FromPem(string pem, string? passphrase = null)
+        {
+            throw new PlatformNotSupportedException("SshKey.FromPem requires .NET 8 or later (BCL ImportFromPem/ImportFromEncryptedPem).");
+        }
+#endif
+
+        private static RsaKey ToRsaKey(RSAParameters p)
+        {
+            return new RsaKey(
+                p.Modulus!.ToBigInteger2().ToByteArray().Reverse().ToBigInteger(),
+                p.Exponent!.ToBigInteger2().ToByteArray().Reverse().ToBigInteger(),
+                p.D!.ToBigInteger2().ToByteArray().Reverse().ToBigInteger(),
+                p.P!.ToBigInteger2().ToByteArray().Reverse().ToBigInteger(),
+                p.Q!.ToBigInteger2().ToByteArray().Reverse().ToBigInteger(),
+                p.InverseQ!.ToBigInteger2().ToByteArray().Reverse().ToBigInteger()
+            );
         }
 
         private static RSA CreateRSA(int keySize)


### PR DESCRIPTION
Bridges BCL crypto keys and PEM into SSH.NET keys.

## API added
- `SshKey.FromKey(RSA rsa, string? comment = null)` -> `GeneratedPrivateKey`
- `SshKey.FromKey(ECDsa ecdsa, string? comment = null)` -> `GeneratedPrivateKey`
- `SshKey.FromEd25519(byte[] key, string? comment = null)` -> `GeneratedPrivateKey` (32-byte seed or 64-byte expanded seed||public)
- `SshKey.FromPem(string pem, string? passphrase = null)` -> `GeneratedPrivateKey`

## Notes
- `FromKey`/`FromEd25519` reuse the exact RSAParameters/ECParameters -> SSH.NET conversions already used by `SshKey.Generate`, so the imported keys match generated ones byte-for-byte. The ECParameters-based ECDSA helpers were made available on all TFMs so `FromKey(ECDsa)` also works on net48.
- `FromPem` uses the BCL `ImportFromPem`/`ImportFromEncryptedPem` (net8.0) and routes through `FromKey`. It handles PKCS#1, SEC1 and PKCS#8, encrypted or not. On netstandard2.0/net48 the BCL lacks these APIs, so `FromPem` throws `PlatformNotSupportedException` (a hand-rolled ASN.1 parser was out of scope; see the `ponytail:` note).
- PKCS#8/PEM export (`ToPkcs8Pem`) was deferred: it is net8.0-only, needs per-type BCL key reconstruction, and has no BCL path for Ed25519. The stated goal was import, so this was left out.

## Tests
`KeyInteropTests` covers RSA, ECDSA (nistp256/384/521) and Ed25519. Each round-trips `FromKey -> ToOpenSshFormat -> PrivateKeyFile` and asserts the fingerprint/public key match, plus an ssh-keygen cross-check that the exported public key parses (skipped if ssh-keygen is absent). An extra RSA test verifies a signature made by the imported key against the original BCL key. PEM import is covered on net8.0; the `PlatformNotSupportedException` path is covered on net48.

Builds on `net48;netstandard2.0;net8.0`. Full suite green on net8.0 and net48.