### PR TITLE
Add OpenSSH certificate signing (SshCertificateBuilder)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ SshNet.Keygen
 * None
 * AES256-cbc
 
+## Certificates
+* Sign OpenSSH user and host certificates (`SshCertificateBuilder`)
+
 ## Usage Examples
 
 ### Builder API
@@ -70,6 +73,51 @@ var key = SshKey.Builder(SshKeyType.RSA)
 var publicKey = key.ToPublic();
 var fingerprint = key.Fingerprint();
 ```
+
+### Sign an OpenSSH Certificate
+
+`SshCertificateBuilder` mints and signs OpenSSH certificates (the `ssh-keygen -s`
+step) for user or host authentication. Point it at the public key to certify,
+set the certificate fields, and sign with your CA key.
+
+```cs
+var caKey = new PrivateKeyFile("ca");            // your CA private key
+var userKey = new PrivateKeyFile("id_ed25519");  // the key to certify
+
+var certificate = new SshCertificateBuilder(userKey)
+    .WithSerial(1)
+    .WithKeyId("alice@example.com")
+    .WithPrincipal("alice")
+    .WithValidity(DateTime.UtcNow, DateTime.UtcNow.AddHours(8))
+    .SignWith(caKey);
+
+// OpenSSH expects the certificate next to the key as <key>-cert.pub
+File.WriteAllText("id_ed25519-cert.pub", certificate.ToOpenSshPublicFormat());
+
+Console.WriteLine(certificate.Fingerprint());
+```
+
+The CA and the key to certify can be freshly generated too, and host
+certificates work the same way:
+
+```cs
+var ca = SshKey.Generate(new SshKeyGenerateInfo(SshKeyType.ED25519));
+var host = SshKey.Generate(new SshKeyGenerateInfo(SshKeyType.ED25519));
+
+var hostCert = new SshCertificateBuilder(host)
+    .WithType(SshCertificateType.Host)
+    .WithPrincipal("host.example.com")
+    .ValidForever()
+    .SignWith(ca);
+```
+
+User certificates get OpenSSH's default extensions (`permit-pty`,
+`permit-user-rc`, …). Override them with `WithExtension`, and add restrictions
+like `force-command` or `source-address` with `WithCriticalOption`. A server
+trusts these certificates when its `TrustedUserCAKeys` names the CA public key
+(user certs), or a client's `known_hosts` `@cert-authority` line does (host
+certs). The resulting certificate can be authenticated with directly, or offered
+through a key agent - see [SshNet.Agent](https://github.com/darinkes/SshNet.Agent).
 
 ### Generate an RSA-2048 Key in File, Show the Public Key and Connect with the Private Key
 

--- a/SshNet.Keygen.Tests/CertificateTests.cs
+++ b/SshNet.Keygen.Tests/CertificateTests.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using Renci.SshNet;
+using Renci.SshNet.Security;
+using Renci.SshNet.Security.Cryptography;
+
+namespace SshNet.Keygen.Tests
+{
+    // Mints signed OpenSSH certificates. The signature is verified two ways: self-contained via
+    // SSH.NET (always on) and, when available, by the real ssh-keygen -L (the ground truth).
+    public class CertificateTests
+    {
+        private static GeneratedPrivateKey Gen(SshKeyType type)
+        {
+            return SshKey.Generate(new SshKeyGenerateInfo(type));
+        }
+
+        private static Key KeyOf(IPrivateKeySource src)
+        {
+            return ((KeyHostAlgorithm)src.HostKeyAlgorithms.First()).Key;
+        }
+
+        [Test]
+        public void SignsAndSelfVerifies(
+            [Values(SshKeyType.RSA, SshKeyType.ECDSA, SshKeyType.ED25519)] SshKeyType certifiedType,
+            [Values(SshKeyType.RSA, SshKeyType.ECDSA, SshKeyType.ED25519)] SshKeyType caType)
+        {
+            var certified = Gen(certifiedType);
+            var ca = Gen(caType);
+
+            var cert = new SshCertificateBuilder(certified)
+                .WithSerial(4711)
+                .WithType(SshCertificateType.User)
+                .WithKeyId("self-verify")
+                .WithPrincipal("alice")
+                .WithPrincipal("bob")
+                .SignWith(ca);
+
+            var (signed, signature) = SplitSignature(cert.ToByteArray(), KeyOf(certified).ToString()!);
+
+            // the CA signature validates over everything preceding it
+            Assert.That(CaHostAlgorithm(KeyOf(ca)).VerifySignature(signed, signature), Is.True);
+
+            // and the leading fields round-trip
+            var r = new Reader(cert.ToByteArray());
+            ClassicAssert.AreEqual($"{KeyOf(certified)}-cert-v01@openssh.com", r.String());
+            r.String();                                   // nonce
+            foreach (var _ in PubFields(KeyOf(certified).ToString()!)) r.String();
+            ClassicAssert.AreEqual(4711UL, r.UInt64());   // serial
+            ClassicAssert.AreEqual(1U, r.UInt32());       // user cert
+            ClassicAssert.AreEqual("self-verify", r.String());
+        }
+
+        [Test]
+        public void SshKeygenAcceptsCertificate(
+            [Values(SshKeyType.RSA, SshKeyType.ECDSA, SshKeyType.ED25519)] SshKeyType certifiedType,
+            [Values(SshKeyType.RSA, SshKeyType.ECDSA, SshKeyType.ED25519)] SshKeyType caType)
+        {
+            if (!OnPath("ssh-keygen"))
+                Assert.Ignore("ssh-keygen not on PATH");
+
+            var certified = Gen(certifiedType);
+            var ca = Gen(caType);
+
+            var cert = new SshCertificateBuilder(certified)
+                .WithSerial(123456789)
+                .WithType(SshCertificateType.User)
+                .WithKeyId("interop-key-id")
+                .WithPrincipals(new[] { "alice", "bob" })
+                .SignWith(ca);
+
+            var dir = Path.Combine(Path.GetTempPath(), "sshnet-keygen-cert", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                var file = Path.Combine(dir, "id-cert.pub");
+                File.WriteAllText(file, cert.ToOpenSshPublicFormat());
+
+                var result = Run("ssh-keygen", $"-L -f \"{file}\"");
+                Assert.That(result.Code, Is.Zero, result.Stderr + result.Stdout);
+
+                StringAssert.Contains("user certificate", result.Stdout);
+                StringAssert.Contains("Serial: 123456789", result.Stdout);
+                StringAssert.Contains("Key ID: \"interop-key-id\"", result.Stdout);
+                StringAssert.Contains("Signing CA", result.Stdout);
+                StringAssert.Contains("alice", result.Stdout);
+                StringAssert.Contains("bob", result.Stdout);
+                // default user extensions are present
+                StringAssert.Contains("permit-pty", result.Stdout);
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch { /* best effort */ }
+            }
+        }
+
+        [Test]
+        public void HostCertificateWithValidityAndCriticalOption()
+        {
+            if (!OnPath("ssh-keygen"))
+                Assert.Ignore("ssh-keygen not on PATH");
+
+            var certified = Gen(SshKeyType.ED25519);
+            var ca = Gen(SshKeyType.RSA);
+
+            var cert = new SshCertificateBuilder(certified)
+                .WithType(SshCertificateType.Host)
+                .WithSerial(7)
+                .WithKeyId("web01")
+                .WithPrincipal("web01.example.com")
+                .WithValidity(new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                              new DateTime(2031, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+                .WithCriticalOption("force-command", "/usr/bin/true")
+                .SignWith(ca);
+
+            var dir = Path.Combine(Path.GetTempPath(), "sshnet-keygen-cert", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                var file = Path.Combine(dir, "host-cert.pub");
+                File.WriteAllText(file, cert.ToOpenSshPublicFormat());
+
+                var result = Run("ssh-keygen", $"-L -f \"{file}\"");
+                Assert.That(result.Code, Is.Zero, result.Stderr + result.Stdout);
+                StringAssert.Contains("host certificate", result.Stdout);
+                StringAssert.Contains("force-command", result.Stdout);
+                StringAssert.Contains("web01.example.com", result.Stdout);
+                // a host cert carries no default extensions
+                StringAssert.Contains("Extensions: (none)", result.Stdout);
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch { /* best effort */ }
+            }
+        }
+
+        [Test]
+        public void FingerprintMatchesSshKeygen(
+            [Values(SshKeyType.RSA, SshKeyType.ECDSA, SshKeyType.ED25519)] SshKeyType certifiedType)
+        {
+            if (!OnPath("ssh-keygen"))
+                Assert.Ignore("ssh-keygen not on PATH");
+
+            var cert = new SshCertificateBuilder(Gen(certifiedType))
+                .WithKeyId("fp").WithPrincipal("alice").SignWith(Gen(SshKeyType.ED25519));
+
+            var dir = Path.Combine(Path.GetTempPath(), "sshnet-keygen-cert", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                var file = Path.Combine(dir, "id-cert.pub");
+                File.WriteAllText(file, cert.ToOpenSshPublicFormat());
+
+                var result = Run("ssh-keygen", $"-l -f \"{file}\"");
+                Assert.That(result.Code, Is.Zero, result.Stderr + result.Stdout);
+                var fingerprint = result.Stdout.Split(' ').First(token => token.StartsWith("SHA256:"));
+                ClassicAssert.AreEqual(fingerprint, cert.Fingerprint());
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch { /* best effort */ }
+            }
+        }
+
+        private static HostAlgorithm CaHostAlgorithm(Key caKey)
+        {
+            if (caKey is RsaKey rsaKey)
+                return new KeyHostAlgorithm("rsa-sha2-512", caKey, new RsaDigitalSignature(rsaKey, System.Security.Cryptography.HashAlgorithmName.SHA512));
+            return new KeyHostAlgorithm(caKey.ToString(), caKey);
+        }
+
+        private static IEnumerable<int> PubFields(string alg)
+        {
+            var count = alg == "ssh-ed25519" ? 1 : 2; // rsa: e,n / ecdsa: curve,Q / ed25519: pk
+            return Enumerable.Range(0, count);
+        }
+
+        // (everything before the trailing signature string, the signature string content)
+        private static (byte[] Signed, byte[] Signature) SplitSignature(byte[] blob, string certifiedAlg)
+        {
+            var r = new Reader(blob);
+            r.String();                          // type
+            r.String();                          // nonce
+            foreach (var _ in PubFields(certifiedAlg)) r.String();
+            r.UInt64();                          // serial
+            r.UInt32();                          // type
+            r.String();                          // key id
+            r.String();                          // principals
+            r.UInt64();                          // valid after
+            r.UInt64();                          // valid before
+            r.String();                          // critical options
+            r.String();                          // extensions
+            r.String();                          // reserved
+            r.String();                          // signature key
+            var signedLen = r.Position;
+            var signature = r.String();
+            var signed = new byte[signedLen];
+            Buffer.BlockCopy(blob, 0, signed, 0, signedLen);
+            return (signed, signature);
+        }
+
+        private sealed class Reader
+        {
+            private readonly byte[] _data;
+            public int Position { get; private set; }
+
+            public Reader(byte[] data) => _data = data;
+
+            public uint UInt32()
+            {
+                var v = ((uint)_data[Position] << 24) | ((uint)_data[Position + 1] << 16) |
+                        ((uint)_data[Position + 2] << 8) | _data[Position + 3];
+                Position += 4;
+                return v;
+            }
+
+            public ulong UInt64()
+            {
+                ulong v = 0;
+                for (var i = 0; i < 8; i++)
+                    v = (v << 8) | _data[Position + i];
+                Position += 8;
+                return v;
+            }
+
+            public byte[] String()
+            {
+                var len = (int)UInt32();
+                var bytes = new byte[len];
+                Buffer.BlockCopy(_data, Position, bytes, 0, len);
+                Position += len;
+                return bytes;
+            }
+        }
+
+        #region ssh-keygen runner
+
+        private static bool OnPath(string exe)
+        {
+            var names = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? new[] { exe + ".exe", exe + ".com", exe }
+                : new[] { exe };
+            return (Environment.GetEnvironmentVariable("PATH") ?? "")
+                .Split(Path.PathSeparator)
+                .Where(d => !string.IsNullOrEmpty(d))
+                .Any(d => names.Any(n => SafeExists(Path.Combine(d, n))));
+        }
+
+        private static bool SafeExists(string path)
+        {
+            try { return File.Exists(path); }
+            catch { return false; }
+        }
+
+        private static (int Code, string Stdout, string Stderr) Run(string exe, string args)
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = exe,
+                Arguments = args,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = Process.Start(psi);
+            var stdout = process!.StandardOutput.ReadToEndAsync();
+            var stderr = process.StandardError.ReadToEndAsync();
+            if (!process.WaitForExit(30000))
+            {
+                try { process.Kill(); } catch { /* already gone */ }
+                Assert.Fail($"{exe} did not exit within 30s");
+            }
+            return (process.ExitCode, stdout.GetAwaiter().GetResult(), stderr.GetAwaiter().GetResult());
+        }
+
+        #endregion
+    }
+}

--- a/SshNet.Keygen/Extensions/BinaryWriterExtension.cs
+++ b/SshNet.Keygen/Extensions/BinaryWriterExtension.cs
@@ -51,5 +51,13 @@ namespace SshNet.Keygen.Extensions
                 Array.Reverse(data);
             writer.Write(data);
         }
+
+        public static void EncodeUInt64(this BinaryWriter writer, ulong i)
+        {
+            var data = BitConverter.GetBytes(i);
+            if (BitConverter.IsLittleEndian)
+                Array.Reverse(data);
+            writer.Write(data);
+        }
     }
 }

--- a/SshNet.Keygen/Extensions/KeyExtension.cs
+++ b/SshNet.Keygen/Extensions/KeyExtension.cs
@@ -309,9 +309,15 @@ namespace SshNet.Keygen.Extensions
 
         #endregion
 
-        private static void PublicKeyData(this Key key, BinaryWriter writer)
+        internal static void PublicKeyData(this Key key, BinaryWriter writer)
         {
             writer.EncodeBinary(key.ToString()!);
+            key.PublicKeyFields(writer);
+        }
+
+        // The type-specific public key fields, without the leading algorithm name.
+        internal static void PublicKeyFields(this Key key, BinaryWriter writer)
+        {
             switch (key.ToString())
             {
                 case "ssh-ed25519":

--- a/SshNet.Keygen/SshCertificate.cs
+++ b/SshNet.Keygen/SshCertificate.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Security.Cryptography;
+
+namespace SshNet.Keygen
+{
+    /// <summary>
+    /// A signed OpenSSH certificate produced by <see cref="SshCertificateBuilder"/>.
+    /// </summary>
+    public class SshCertificate
+    {
+        /// <summary>The certificate wire blob (the base64-encoded part of a *-cert-v01 line).</summary>
+        public byte[] Blob { get; }
+
+        /// <summary>The certificate type name, e.g. <c>ssh-ed25519-cert-v01@openssh.com</c>.</summary>
+        public string TypeName { get; }
+
+        /// <summary>The trailing comment used on the public certificate line.</summary>
+        public string Comment { get; }
+
+        private readonly byte[] _publicKeyBlob;
+
+        internal SshCertificate(string typeName, byte[] blob, byte[] publicKeyBlob, string comment)
+        {
+            TypeName = typeName;
+            Blob = blob;
+            _publicKeyBlob = publicKeyBlob;
+            Comment = comment;
+        }
+
+        /// <summary>The certificate wire blob.</summary>
+        public byte[] ToByteArray()
+        {
+            return Blob;
+        }
+
+        /// <summary>The public certificate line: <c>&lt;type&gt; &lt;base64(blob)&gt; &lt;comment&gt;</c>.</summary>
+        public string ToOpenSshPublicFormat()
+        {
+            return $"{TypeName} {Convert.ToBase64String(Blob)} {Comment}\n";
+        }
+
+        /// <summary>
+        /// The SHA256 fingerprint (<c>SHA256:...</c>) of the certified public key, matching
+        /// what <c>ssh-keygen -l</c> reports for the certificate.
+        /// </summary>
+        public string Fingerprint()
+        {
+            using var sha256 = SHA256.Create();
+            var hash = sha256.ComputeHash(_publicKeyBlob);
+            return $"SHA256:{Convert.ToBase64String(hash).TrimEnd('=')}";
+        }
+    }
+}

--- a/SshNet.Keygen/SshCertificateBuilder.cs
+++ b/SshNet.Keygen/SshCertificateBuilder.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using Renci.SshNet;
+using Renci.SshNet.Security;
+using Renci.SshNet.Security.Cryptography;
+using SshNet.Keygen.Extensions;
+
+namespace SshNet.Keygen
+{
+    /// <summary>
+    /// Fluent builder that mints and signs an OpenSSH certificate (the <c>ssh-keygen -s</c> step).
+    /// </summary>
+    public class SshCertificateBuilder
+    {
+        // OpenSSH's default user-certificate extensions (all flag-only, empty data).
+        private static readonly string[] DefaultUserExtensionNames =
+        {
+            "permit-X11-forwarding", "permit-agent-forwarding", "permit-port-forwarding",
+            "permit-pty", "permit-user-rc"
+        };
+
+        private readonly Key _publicKey;
+        private ulong _serial;
+        private SshCertificateType _type = SshCertificateType.User;
+        private string _keyId = "";
+        private readonly List<string> _principals = new();
+        private ulong _validAfter;
+        private ulong _validBefore = ulong.MaxValue;
+        private readonly SortedDictionary<string, string> _criticalOptions = new(StringComparer.Ordinal);
+        private readonly SortedDictionary<string, string> _extensions = new(StringComparer.Ordinal);
+        private bool _extensionsSet;
+        private byte[]? _nonce;
+
+        /// <summary>Starts a certificate for the given public key to certify.</summary>
+        /// <param name="publicKey">The key to certify (only its public part is used).</param>
+        public SshCertificateBuilder(Key publicKey)
+        {
+            _publicKey = publicKey ?? throw new ArgumentNullException(nameof(publicKey));
+        }
+
+        /// <summary>Starts a certificate for the public key of the given source.</summary>
+        /// <param name="publicKey">The key source to certify.</param>
+        public SshCertificateBuilder(IPrivateKeySource publicKey) : this(KeyOf(publicKey))
+        {
+        }
+
+        /// <summary>Sets the certificate serial number.</summary>
+        /// <param name="serial">The serial number.</param>
+        public SshCertificateBuilder WithSerial(ulong serial)
+        {
+            _serial = serial;
+            return this;
+        }
+
+        /// <summary>Sets the certificate type (user or host).</summary>
+        /// <param name="type">The certificate type.</param>
+        public SshCertificateBuilder WithType(SshCertificateType type)
+        {
+            _type = type;
+            return this;
+        }
+
+        /// <summary>Sets the key id (a human-readable label recorded in the certificate).</summary>
+        /// <param name="keyId">The key id.</param>
+        public SshCertificateBuilder WithKeyId(string keyId)
+        {
+            _keyId = keyId ?? "";
+            return this;
+        }
+
+        /// <summary>Adds a valid principal (a username for user certs, a hostname for host certs).</summary>
+        /// <param name="principal">The principal.</param>
+        public SshCertificateBuilder WithPrincipal(string principal)
+        {
+            _principals.Add(principal);
+            return this;
+        }
+
+        /// <summary>Adds valid principals. An empty set means the certificate is valid for all principals.</summary>
+        /// <param name="principals">The principals.</param>
+        public SshCertificateBuilder WithPrincipals(IEnumerable<string> principals)
+        {
+            _principals.AddRange(principals);
+            return this;
+        }
+
+        /// <summary>Sets the validity window.</summary>
+        /// <param name="validAfter">Not valid before this time.</param>
+        /// <param name="validBefore">Not valid after this time.</param>
+        public SshCertificateBuilder WithValidity(DateTime validAfter, DateTime validBefore)
+        {
+            _validAfter = ToUnixSeconds(validAfter);
+            _validBefore = ToUnixSeconds(validBefore);
+            return this;
+        }
+
+        /// <summary>Marks the certificate valid forever (the default).</summary>
+        public SshCertificateBuilder ValidForever()
+        {
+            _validAfter = 0;
+            _validBefore = ulong.MaxValue;
+            return this;
+        }
+
+        /// <summary>Adds a critical option (e.g. <c>force-command</c>, <c>source-address</c>).</summary>
+        /// <param name="name">The option name.</param>
+        /// <param name="data">The option value.</param>
+        public SshCertificateBuilder WithCriticalOption(string name, string data)
+        {
+            _criticalOptions[name] = data ?? "";
+            return this;
+        }
+
+        /// <summary>Adds an extension. Setting any extension replaces the default user extensions.</summary>
+        /// <param name="name">The extension name.</param>
+        /// <param name="data">The extension value (empty for flag extensions).</param>
+        public SshCertificateBuilder WithExtension(string name, string data = "")
+        {
+            _extensionsSet = true;
+            _extensions[name] = data ?? "";
+            return this;
+        }
+
+        /// <summary>Sets the certificate nonce. If unset, 32 random bytes are generated.</summary>
+        /// <param name="nonce">The nonce.</param>
+        public SshCertificateBuilder WithNonce(byte[] nonce)
+        {
+            _nonce = nonce;
+            return this;
+        }
+
+        /// <summary>Signs the certificate with the given CA key source.</summary>
+        /// <param name="caKey">The CA key source (must hold a private key).</param>
+        public SshCertificate SignWith(IPrivateKeySource caKey)
+        {
+            return SignWith(KeyOf(caKey));
+        }
+
+        /// <summary>Signs the certificate with the given CA key.</summary>
+        /// <param name="caKey">The CA key (must hold a private key).</param>
+        public SshCertificate SignWith(Key caKey)
+        {
+            if (caKey is null)
+                throw new ArgumentNullException(nameof(caKey));
+
+            var typeName = $"{_publicKey}-cert-v01@openssh.com";
+            var nonce = _nonce ?? RandomBytes(32);
+
+            using var stream = new MemoryStream();
+            using var writer = new BinaryWriter(stream);
+
+            writer.EncodeBinary(typeName);
+            writer.EncodeBinary(nonce);
+            _publicKey.PublicKeyFields(writer);           // type-specific public fields of the certified key
+            writer.EncodeUInt64(_serial);
+            writer.EncodeUInt((uint)_type);
+            writer.EncodeBinary(_keyId);
+            writer.EncodeBinary(EncodeStrings(_principals));
+            writer.EncodeUInt64(_validAfter);
+            writer.EncodeUInt64(_validBefore);
+            writer.EncodeBinary(EncodeOptions(_criticalOptions));
+            writer.EncodeBinary(EncodeOptions(EffectiveExtensions()));
+            writer.EncodeBinary("");                      // reserved
+            writer.EncodeBinary(PublicKeyBlob(caKey));    // signature key: CA public key blob
+
+            // signature over everything serialized so far
+            var signature = CaHostAlgorithm(caKey).Sign(stream.ToArray());
+            writer.EncodeBinary(signature);
+
+            var comment = string.IsNullOrEmpty(_publicKey.Comment) ? _keyId : _publicKey.Comment;
+            return new SshCertificate(typeName, stream.ToArray(), PublicKeyBlob(_publicKey), comment);
+        }
+
+        private SortedDictionary<string, string> EffectiveExtensions()
+        {
+            if (_extensionsSet || _type != SshCertificateType.User)
+                return _extensions;
+
+            var defaults = new SortedDictionary<string, string>(StringComparer.Ordinal);
+            foreach (var name in DefaultUserExtensionNames)
+                defaults[name] = "";
+            return defaults;
+        }
+
+        private static HostAlgorithm CaHostAlgorithm(Key caKey)
+        {
+            // OpenSSH signs certificates with an RSA CA using rsa-sha2-512; other key types use their native algorithm.
+            if (caKey is RsaKey rsaKey)
+                return new KeyHostAlgorithm("rsa-sha2-512", caKey, new RsaDigitalSignature(rsaKey, HashAlgorithmName.SHA512));
+            return new KeyHostAlgorithm(caKey.ToString(), caKey);
+        }
+
+        private static byte[] PublicKeyBlob(Key key)
+        {
+            using var stream = new MemoryStream();
+            using var writer = new BinaryWriter(stream);
+            key.PublicKeyData(writer);
+            return stream.ToArray();
+        }
+
+        // A sequence of SSH strings, concatenated (used for the principals list).
+        private static byte[] EncodeStrings(IEnumerable<string> items)
+        {
+            using var stream = new MemoryStream();
+            using var writer = new BinaryWriter(stream);
+            foreach (var item in items)
+                writer.EncodeBinary(item);
+            return stream.ToArray();
+        }
+
+        // A sequence of (name, data) pairs. Flag options carry an empty data string; valued options
+        // wrap their value in an inner SSH string, per PROTOCOL.certkeys.
+        private static byte[] EncodeOptions(SortedDictionary<string, string> options)
+        {
+            using var stream = new MemoryStream();
+            using var writer = new BinaryWriter(stream);
+            foreach (var option in options)
+            {
+                writer.EncodeBinary(option.Key);
+                if (string.IsNullOrEmpty(option.Value))
+                {
+                    writer.EncodeBinary("");
+                }
+                else
+                {
+                    using var inner = new MemoryStream();
+                    using var innerWriter = new BinaryWriter(inner);
+                    innerWriter.EncodeBinary(option.Value);
+                    writer.EncodeBinary(inner.ToArray());
+                }
+            }
+            return stream.ToArray();
+        }
+
+        private static Key KeyOf(IPrivateKeySource source)
+        {
+            return ((KeyHostAlgorithm)source.HostKeyAlgorithms.First()).Key;
+        }
+
+        private static byte[] RandomBytes(int count)
+        {
+            var bytes = new byte[count];
+            using var rng = RandomNumberGenerator.Create();
+            rng.GetBytes(bytes);
+            return bytes;
+        }
+
+        private static ulong ToUnixSeconds(DateTime dt)
+        {
+            var seconds = new DateTimeOffset(dt.ToUniversalTime()).ToUnixTimeSeconds();
+            return seconds < 0 ? 0 : (ulong)seconds;
+        }
+    }
+}

--- a/SshNet.Keygen/SshCertificateType.cs
+++ b/SshNet.Keygen/SshCertificateType.cs
@@ -1,0 +1,14 @@
+namespace SshNet.Keygen
+{
+    /// <summary>
+    /// The kind of OpenSSH certificate being minted.
+    /// </summary>
+    public enum SshCertificateType : uint
+    {
+        /// <summary>A user certificate (authenticates a user to a host).</summary>
+        User = 1,
+
+        /// <summary>A host certificate (authenticates a host to a user).</summary>
+        Host = 2
+    }
+}


### PR DESCRIPTION
Mints and signs OpenSSH user/host certificates - the `ssh-keygen -s` step, which nothing in .NET does well.

## API added
- `SshCertificateBuilder(Key publicKey)` / `SshCertificateBuilder(IPrivateKeySource publicKey)` - the key to certify
- `.WithSerial(ulong)`, `.WithType(SshCertificateType)`, `.WithKeyId(string)`
- `.WithPrincipal(string)`, `.WithPrincipals(IEnumerable<string>)`
- `.WithValidity(DateTime after, DateTime before)`, `.ValidForever()`
- `.WithCriticalOption(string name, string data)`, `.WithExtension(string name, string data = "")`
- `.WithNonce(byte[])` (32 random bytes by default)
- `.SignWith(Key caKey)` / `.SignWith(IPrivateKeySource caKey)` -> `SshCertificate`
- `enum SshCertificateType { User = 1, Host = 2 }`
- `SshCertificate` with `.ToByteArray()`, `.ToOpenSshPublicFormat()`, `.Fingerprint()`, and `Blob`/`TypeName`/`Comment`

## Implementation
- Serializes the OpenSSH certificate wire format from PROTOCOL.certkeys exactly, reusing the existing `BinaryWriterExtension` encoders and the key public-key writers in `KeyExtension`. `PublicKeyData` was split so the type-specific public fields (used for the certified key body) can be reused; `BinaryWriterExtension` gained `EncodeUInt64`.
- Critical options / extensions are emitted sorted by name (ordinal); flag options carry an empty data string, valued options wrap their value in an inner SSH string.
- An RSA CA signs with `rsa-sha2-512`; ecdsa/ed25519 CAs use their native algorithm. Signatures are produced by SSH.NET's `KeyHostAlgorithm`, so the signature field is the full SSH signature blob.
- Default user certificates get OpenSSH's standard extensions (permit-X11-forwarding, permit-agent-forwarding, permit-port-forwarding, permit-pty, permit-user-rc); host certificates get none. Setting any extension replaces the defaults.

## Verification
`CertificateTests` builds certs for every rsa/ecdsa/ed25519 combination as both the certified key and the CA and:
- verifies the CA signature self-contained via SSH.NET (always on), and
- runs the real `ssh-keygen -L -f <file>` and asserts it reports the right type, serial, key id, principals, Signing CA and extensions (skipped gracefully if ssh-keygen is absent). Verified against both Git-for-Windows and Windows OpenSSH ssh-keygen. A host-certificate test additionally checks a validity window and a `force-command` critical option.

Builds on `net48;netstandard2.0;net8.0`. Full suite green on net8.0 and net48.