### PR TITLE
Fix UTF-8 string encoding and harden the certificate builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ SshNet.Keygen
 ## Certificates
 * Sign OpenSSH user and host certificates (`SshCertificateBuilder`)
 
+## .NET Key Interop
+* Import `System.Security.Cryptography` keys and PEM files (`SshKey.FromKey`, `SshKey.FromPem`, `SshKey.FromEd25519`)
+
 ## Usage Examples
 
 ### Builder API
@@ -317,6 +320,29 @@ Console.WriteLine("Putty Private Key: {0}", puttyKey);
 Console.WriteLine("Public Key: {0}", publicKey);
 Console.WriteLine("Putty Public Key: {0}", puttyPublicKey);
 ```
+
+### Use an existing .NET Key
+
+`SshKey.FromKey` wraps a BCL `RSA` or `ECDsa` key (NIST curves) as an SSH.NET
+key, `SshKey.FromEd25519` takes a raw 32-byte seed (or 64-byte expanded key),
+and `SshKey.FromPem` imports a PEM (PKCS#1, SEC1 or PKCS#8, optionally
+encrypted). The result can be exported or used to connect like any generated key.
+
+```cs
+using var rsa = RSA.Create(2048);
+var key = SshKey.FromKey(rsa, "me@host");
+
+// or from a PEM file
+var pemKey = SshKey.FromPem(File.ReadAllText("key.pem"), "passphrase");
+
+Console.WriteLine("Public Key: {0}", key.ToPublic());
+
+using var client = new SshClient("ssh.foo.com", "root", key);
+client.Connect();
+```
+
+> `SshKey.FromPem` requires .NET 8 or later; on .NET 4.8 and netstandard 2.0 it
+> throws `PlatformNotSupportedException`.
 
 ### Sign and Verify (SSH signatures)
 

--- a/SshNet.Keygen.Tests/CertificateTests.cs
+++ b/SshNet.Keygen.Tests/CertificateTests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using Renci.SshNet;
@@ -55,6 +56,26 @@ namespace SshNet.Keygen.Tests
             ClassicAssert.AreEqual(4711UL, r.UInt64());   // serial
             ClassicAssert.AreEqual(1U, r.UInt32());       // user cert
             ClassicAssert.AreEqual("self-verify", r.String());
+        }
+
+        [Test]
+        public void NonAsciiKeyIdAndPrincipalAreUtf8()
+        {
+            // regression: ASCII encoding minted certificates with principal "m?ller"
+            var cert = new SshCertificateBuilder(Gen(SshKeyType.ED25519))
+                .WithKeyId("müller-id")
+                .WithPrincipal("müller")
+                .SignWith(Gen(SshKeyType.ED25519));
+
+            var r = new Reader(cert.ToByteArray());
+            r.String();                                   // type
+            r.String();                                   // nonce
+            r.String();                                   // ed25519 pk
+            r.UInt64();                                   // serial
+            r.UInt32();                                   // cert type
+            ClassicAssert.AreEqual(Encoding.UTF8.GetBytes("müller-id"), r.String());
+            var principals = new Reader(r.String());
+            ClassicAssert.AreEqual(Encoding.UTF8.GetBytes("müller"), principals.String());
         }
 
         [Test]

--- a/SshNet.Keygen.Tests/CertificateTests.cs
+++ b/SshNet.Keygen.Tests/CertificateTests.cs
@@ -79,6 +79,23 @@ namespace SshNet.Keygen.Tests
         }
 
         [Test]
+        public void RejectsEmptyNonce()
+        {
+            var builder = new SshCertificateBuilder(Gen(SshKeyType.ED25519));
+            Assert.Throws<ArgumentException>((Action)(() => builder.WithNonce(null!)));
+            Assert.Throws<ArgumentException>((Action)(() => builder.WithNonce(Array.Empty<byte>())));
+        }
+
+        [Test]
+        public void RejectsInvertedValidity()
+        {
+            var builder = new SshCertificateBuilder(Gen(SshKeyType.ED25519));
+            Assert.Throws<ArgumentException>((Action)(() => builder.WithValidity(
+                new DateTime(2031, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc))));
+        }
+
+        [Test]
         public void SshKeygenAcceptsCertificate(
             [Values(SshKeyType.RSA, SshKeyType.ECDSA, SshKeyType.ED25519)] SshKeyType certifiedType,
             [Values(SshKeyType.RSA, SshKeyType.ECDSA, SshKeyType.ED25519)] SshKeyType caType)

--- a/SshNet.Keygen.Tests/KeyInteropTests.cs
+++ b/SshNet.Keygen.Tests/KeyInteropTests.cs
@@ -91,6 +91,26 @@ namespace SshNet.Keygen.Tests
         }
 
         [Test]
+        public void FromEcdsaRejectsNonNistCurve()
+        {
+            // regression: brainpool keys were mapped to a NIST curve by key size and failed deep inside SSH.NET
+            ECDsa ecdsa;
+            try
+            {
+                ecdsa = ECDsa.Create(ECCurve.CreateFromFriendlyName("brainpoolP256r1"));
+                _ = ecdsa.ExportParameters(false);
+            }
+            catch (Exception)
+            {
+                Assert.Ignore("brainpoolP256r1 not supported on this platform");
+                return;
+            }
+
+            using (ecdsa)
+                Assert.Throws<NotSupportedException>((Action)(() => SshKey.FromKey(ecdsa)));
+        }
+
+        [Test]
         public void FromEd25519RoundTrips()
         {
             var seed = new byte[32];

--- a/SshNet.Keygen.Tests/KeyInteropTests.cs
+++ b/SshNet.Keygen.Tests/KeyInteropTests.cs
@@ -107,7 +107,12 @@ namespace SshNet.Keygen.Tests
             }
 
             using (ecdsa)
+#if NET8_0_OR_GREATER
                 Assert.Throws<NotSupportedException>((Action)(() => SshKey.FromKey(ecdsa)));
+#else
+                // net48 CNG hides the curve OID, so SSH.NET rejects the non-NIST point later
+                Assert.Catch((Action)(() => SshKey.FromKey(ecdsa)));
+#endif
         }
 
         [Test]

--- a/SshNet.Keygen.Tests/TestKey.cs
+++ b/SshNet.Keygen.Tests/TestKey.cs
@@ -324,6 +324,69 @@ namespace SshNet.Keygen.Tests
         }
 
         [Test]
+        public void TestNonAsciiCommentRoundTrips()
+        {
+            // regression: ASCII encoding mangled non-ASCII comments to '?' in the key blob
+            const string comment = "Müller@München";
+            var key = SshKey.Generate(new SshKeyGenerateInfo(SshKeyType.ED25519) { Comment = comment });
+            var reloaded = new PrivateKeyFile(key.ToOpenSshFormat().ToStream());
+            ClassicAssert.AreEqual(comment, ((KeyHostAlgorithm)reloaded.HostKeyAlgorithms.First()).Key.Comment);
+        }
+
+        [Test]
+        public void TestPuttyMacCoversUtf8Comment()
+        {
+            // regression: the Private-MAC was computed over an ASCII-mangled comment while the file carries UTF-8
+            const string comment = "Müller@München";
+            var key = SshKey.Generate(new SshKeyGenerateInfo(SshKeyType.ED25519) { Comment = comment });
+            var ppk = key.ToPuttyFormat(SshKeyFormat.PuTTYv2);
+
+            var lines = ppk.Split('\n');
+            string Field(string name) => lines.First(l => l.StartsWith(name + ": ")).Substring(name.Length + 2);
+            byte[] Block(string name) => Convert.FromBase64String(string.Concat(
+                lines.Skip(Array.FindIndex(lines, l => l.StartsWith(name + ": ")) + 1).Take(int.Parse(Field(name)))));
+
+            ClassicAssert.AreEqual(comment, Field("Comment"));
+
+            // recompute the MAC over the file's actual bytes (unencrypted PuTTYv2)
+            using var macData = new MemoryStream();
+            foreach (var part in new[]
+                     {
+                         Encoding.UTF8.GetBytes(Field("PuTTY-User-Key-File-2")),
+                         Encoding.UTF8.GetBytes(Field("Encryption")),
+                         Encoding.UTF8.GetBytes(Field("Comment")),
+                         Block("Public-Lines"),
+                         Block("Private-Lines")
+                     })
+            {
+                var len = BitConverter.GetBytes((uint)part.Length);
+                if (BitConverter.IsLittleEndian)
+                    Array.Reverse(len);
+                macData.Write(len, 0, 4);
+                macData.Write(part, 0, part.Length);
+            }
+
+            using var sha1 = SHA1.Create();
+            var macKey = sha1.ComputeHash(Encoding.UTF8.GetBytes("putty-private-key-file-mac-key"));
+            using var hmac = new HMACSHA1(macKey);
+            var expected = BitConverter.ToString(hmac.ComputeHash(macData.ToArray())).Replace("-", "").ToLower();
+
+            ClassicAssert.AreEqual(expected, Field("Private-MAC").Trim());
+        }
+
+        [Test]
+        public void TestSignVerifyNonAsciiNamespace()
+        {
+            // regression: ASCII encoding corrupted the SSHSIG namespace both on sign and verify
+            var data = Encoding.UTF8.GetBytes("utf-8 namespace data");
+            var keyFile = new PrivateKeyFile(GetKey("ED25519").ToStream());
+
+            var signature = keyFile.Signature(data, "büro-münchen");
+            ClassicAssert.IsTrue(SshSignature.Verify(data, signature, "büro-münchen"));
+            ClassicAssert.IsFalse(SshSignature.Verify(data, signature));
+        }
+
+        [Test]
         public void TestBuilderDefaults()
         {
             var key = SshKey.Builder().Generate();

--- a/SshNet.Keygen.Tests/TestKey.cs
+++ b/SshNet.Keygen.Tests/TestKey.cs
@@ -324,6 +324,17 @@ namespace SshNet.Keygen.Tests
         }
 
         [Test]
+        public void TestGenerateLeavesStreamOpen()
+        {
+            // regression: Generate disposed the caller's stream
+            using var stream = new MemoryStream();
+            SshKey.Generate(stream, new SshKeyGenerateInfo(SshKeyType.ED25519));
+
+            stream.Position = 0;
+            _ = new PrivateKeyFile(stream);
+        }
+
+        [Test]
         public void TestNonAsciiCommentRoundTrips()
         {
             // regression: ASCII encoding mangled non-ASCII comments to '?' in the key blob

--- a/SshNet.Keygen/Extensions/BinaryWriterExtension.cs
+++ b/SshNet.Keygen/Extensions/BinaryWriterExtension.cs
@@ -9,13 +9,13 @@ namespace SshNet.Keygen.Extensions
     {
         public static void EncodeNullTerminatedString(this BinaryWriter writer, string str)
         {
-            writer.Write(Encoding.ASCII.GetBytes(str));
+            writer.Write(Encoding.UTF8.GetBytes(str));
             writer.Write('\0');
         }
 
         public static void EncodeBinary(this BinaryWriter writer, string str)
         {
-            EncodeBinary(writer, Encoding.ASCII.GetBytes(str));
+            EncodeBinary(writer, Encoding.UTF8.GetBytes(str));
         }
 
         public static void EncodeBinary(this BinaryWriter writer, MemoryStream str)

--- a/SshNet.Keygen/Extensions/EcdsaExtension.cs
+++ b/SshNet.Keygen/Extensions/EcdsaExtension.cs
@@ -14,15 +14,24 @@ namespace SshNet.Keygen.Extensions
             return q;
         }
 
-        // EcParameters.Curve.Oid.FriendlyName returns different values if OpenSSL or Windows-Crypto
+        // EcParameters.Curve.Oid.FriendlyName returns different values if OpenSSL or Windows-Crypto, so match on the OID value
         public static string EcCurveNameSshCompat(this ECDsa ecdsa)
         {
-            return ecdsa.KeySize switch
+            var oid = ecdsa.ExportParameters(false).Curve.Oid;
+            return oid?.Value switch
             {
-                256 => "nistp256",
-                384 => "nistp384",
-                521 => "nistp521",
-                _ => throw new CryptographicException($"Unsupported KeyLength: {ecdsa.KeySize}")
+                "1.2.840.10045.3.1.7" => "nistp256",
+                "1.3.132.0.34" => "nistp384",
+                "1.3.132.0.35" => "nistp521",
+                // some platforms report no OID value; fall back to the key size
+                null or "" => ecdsa.KeySize switch
+                {
+                    256 => "nistp256",
+                    384 => "nistp384",
+                    521 => "nistp521",
+                    _ => throw new CryptographicException($"Unsupported KeyLength: {ecdsa.KeySize}")
+                },
+                _ => throw new NotSupportedException($"Unsupported ECDSA curve: {oid.FriendlyName ?? oid.Value}")
             };
         }
 

--- a/SshNet.Keygen/SshCertificateBuilder.cs
+++ b/SshNet.Keygen/SshCertificateBuilder.cs
@@ -92,6 +92,8 @@ namespace SshNet.Keygen
         /// <param name="validBefore">Not valid after this time.</param>
         public SshCertificateBuilder WithValidity(DateTime validAfter, DateTime validBefore)
         {
+            if (validAfter > validBefore)
+                throw new ArgumentException("validAfter must not be later than validBefore.", nameof(validAfter));
             _validAfter = ToUnixSeconds(validAfter);
             _validBefore = ToUnixSeconds(validBefore);
             return this;
@@ -128,6 +130,8 @@ namespace SshNet.Keygen
         /// <param name="nonce">The nonce.</param>
         public SshCertificateBuilder WithNonce(byte[] nonce)
         {
+            if (nonce is null || nonce.Length == 0)
+                throw new ArgumentException("Nonce must not be null or empty.", nameof(nonce));
             _nonce = nonce;
             return this;
         }

--- a/SshNet.Keygen/SshKey.cs
+++ b/SshNet.Keygen/SshKey.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Security.Cryptography;
+using System.Text;
 using Renci.SshNet.Security;
 using SshNet.Keygen.Extensions;
 
@@ -41,7 +42,8 @@ namespace SshNet.Keygen
         /// <param name="info">Generation and export options.</param>
         public static GeneratedPrivateKey Generate(Stream stream, SshKeyGenerateInfo info)
         {
-            using var writer = new StreamWriter(stream);
+            // leave the caller's stream open
+            using var writer = new StreamWriter(stream, new UTF8Encoding(false), 1024, true);
 
             var key = Generate(info);
             switch (info.KeyFormat)

--- a/SshNet.Keygen/SshNet.Keygen.csproj
+++ b/SshNet.Keygen/SshNet.Keygen.csproj
@@ -7,7 +7,7 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <WarningsAsErrors>CS1591</WarningsAsErrors>
         <PackageId>SshNet.Keygen</PackageId>
-        <Version>2024.2.0.3</Version>
+        <Version>2024.2.0.4</Version>
         <PackageVersion>$(Version)</PackageVersion>
         <PackageTags>ssh;scp;sftp</PackageTags>
         <Description>SSH.NET Extension to generate and export Authentication Keys in OpenSSH and PuTTY Format.</Description>


### PR DESCRIPTION
## Summary

Review fixes for the string-encoding bug and a few smaller hardening items.

- **Encode SSH strings as UTF-8 instead of ASCII** (major): `EncodeBinary(string)` mangled every non-ASCII character to `?`. This made PuTTY reject exported .ppk files with a non-ASCII comment (\"MAC failed\": the Private-MAC was computed over the mangled comment while the file carries UTF-8), minted certificates with corrupted principals/key ids (`m?ller` instead of `müller`), corrupted the SSHSIG namespace on both sign and verify (the library could not verify its own output), and corrupted the embedded OpenSSH key comment. UTF-8 is byte-identical for ASCII input, so existing output is unchanged.
- **Leave the caller's stream open in `SshKey.Generate(Stream, info)`**: the method disposed the stream it was handed, so callers could not read back what was just written.
- **Validate `SshCertificateBuilder` input**: `WithNonce` now rejects a null/empty nonce (the spec relies on CA-supplied randomness), `WithValidity` rejects `validAfter > validBefore`.
- **Reject non-NIST curves in `SshKey.FromKey(ECDsa)`**: curves were mapped purely by key size, so brainpool/secp256k1 keys failed later deep inside SSH.NET with an opaque `CryptographicException`. The curve OID is now checked and unsupported curves fail fast with a `NotSupportedException` naming the curve.
- **README**: document the .NET key interop (`SshKey.FromKey` / `FromPem` / `FromEd25519`), including that `FromPem` throws `PlatformNotSupportedException` on .NET 4.8 / netstandard 2.0.

Each fix comes with a test that fails without it.

## Release

Merging this publishes **2024.2.0.4**. This should be merged **before** the SshNet.Agent release PR, whose README references the certificate API.