### PR TITLE
Sign certificates with an external CA signer

### DIFF
--- a/SshNet.Keygen.Tests/CertificateTests.cs
+++ b/SshNet.Keygen.Tests/CertificateTests.cs
@@ -59,6 +59,27 @@ namespace SshNet.Keygen.Tests
         }
 
         [Test]
+        public void SignWithHostAlgorithmSelfVerifies(
+            [Values(SshKeyType.RSA, SshKeyType.ECDSA, SshKeyType.ED25519)] SshKeyType caType)
+        {
+            var certified = Gen(SshKeyType.ECDSA);
+            var ca = Gen(caType);
+
+            // an external signer (a TPM/HSM-backed IPrivateKeySource) supplies a host algorithm instead
+            // of handing over the private key; the builder signs through it
+            var caAlgorithm = (KeyHostAlgorithm)CaHostAlgorithm(KeyOf(ca));
+
+            var cert = new SshCertificateBuilder(certified)
+                .WithType(SshCertificateType.User)
+                .WithKeyId("ext-signer")
+                .WithPrincipal("alice")
+                .SignWith(caAlgorithm);
+
+            var (signed, signature) = SplitSignature(cert.ToByteArray(), KeyOf(certified).ToString()!);
+            Assert.That(CaHostAlgorithm(KeyOf(ca)).VerifySignature(signed, signature), Is.True);
+        }
+
+        [Test]
         public void NonAsciiKeyIdAndPrincipalAreUtf8()
         {
             // regression: ASCII encoding minted certificates with principal "m?ller"

--- a/SshNet.Keygen/SshCertificateBuilder.cs
+++ b/SshNet.Keygen/SshCertificateBuilder.cs
@@ -150,6 +150,26 @@ namespace SshNet.Keygen
             if (caKey is null)
                 throw new ArgumentNullException(nameof(caKey));
 
+            return Sign(CaHostAlgorithm(caKey));
+        }
+
+        /// <summary>
+        /// Signs the certificate with the given CA host algorithm. Use this when the CA private key
+        /// lives outside the process — in a TPM or HSM — and cannot be handed over as a <see cref="Key"/>:
+        /// the algorithm carries the signer, so the key is never exported. Pass, for example, the first
+        /// entry of an <see cref="IPrivateKeySource.HostKeyAlgorithms"/> backed by such a signer.
+        /// </summary>
+        /// <param name="caAlgorithm">The CA host algorithm; its key and signer sign the certificate.</param>
+        public SshCertificate SignWith(KeyHostAlgorithm caAlgorithm)
+        {
+            if (caAlgorithm is null)
+                throw new ArgumentNullException(nameof(caAlgorithm));
+
+            return Sign(caAlgorithm);
+        }
+
+        private SshCertificate Sign(KeyHostAlgorithm ca)
+        {
             var typeName = $"{_publicKey}-cert-v01@openssh.com";
             var nonce = _nonce ?? RandomBytes(32);
 
@@ -168,10 +188,10 @@ namespace SshNet.Keygen
             writer.EncodeBinary(EncodeOptions(_criticalOptions));
             writer.EncodeBinary(EncodeOptions(EffectiveExtensions()));
             writer.EncodeBinary("");                      // reserved
-            writer.EncodeBinary(PublicKeyBlob(caKey));    // signature key: CA public key blob
+            writer.EncodeBinary(PublicKeyBlob(ca.Key));   // signature key: CA public key blob
 
             // signature over everything serialized so far
-            var signature = CaHostAlgorithm(caKey).Sign(stream.ToArray());
+            var signature = ca.Sign(stream.ToArray());
             writer.EncodeBinary(signature);
 
             var comment = string.IsNullOrEmpty(_publicKey.Comment) ? _keyId : _publicKey.Comment;
@@ -189,7 +209,7 @@ namespace SshNet.Keygen
             return defaults;
         }
 
-        private static HostAlgorithm CaHostAlgorithm(Key caKey)
+        private static KeyHostAlgorithm CaHostAlgorithm(Key caKey)
         {
             // OpenSSH signs certificates with an RSA CA using rsa-sha2-512; other key types use their native algorithm.
             if (caKey is RsaKey rsaKey)

--- a/SshNet.Keygen/SshNet.Keygen.csproj
+++ b/SshNet.Keygen/SshNet.Keygen.csproj
@@ -7,7 +7,7 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <WarningsAsErrors>CS1591</WarningsAsErrors>
         <PackageId>SshNet.Keygen</PackageId>
-        <Version>2024.2.0.4</Version>
+        <Version>2024.2.0.5</Version>
         <PackageVersion>$(Version)</PackageVersion>
         <PackageTags>ssh;scp;sftp</PackageTags>
         <Description>SSH.NET Extension to generate and export Authentication Keys in OpenSSH and PuTTY Format.</Description>


### PR DESCRIPTION
## Why

`SshCertificateBuilder.SignWith` signs with the CA key's *embedded* private material — it rebuilds a signature from the `Key`. So a CA whose private key lives outside the process (a TPM or HSM) cannot sign a certificate: the exported public-only `Key` has no private part, and signing throws `missing private key`.

## Changes

- **`SignWith(KeyHostAlgorithm caAlgorithm)`** — new overload that signs through the algorithm's own signer, so the CA key is never exported. Pass, for example, the first entry of an `IPrivateKeySource.HostKeyAlgorithms` backed by a TPM/HSM signer.
- The signing body is factored into a private `Sign(KeyHostAlgorithm)`; `SignWith(Key)` now delegates to it via `CaHostAlgorithm(caKey)`, so existing behaviour (including an RSA CA signing with `rsa-sha2-512`) is unchanged.
- New test `SignWithHostAlgorithmSelfVerifies` over RSA/ECDSA/ED25519 CAs, driving the external-signer path.

## Testing

Full certificate suite (28 tests) passes on net48 and net8.0, including the `ssh-keygen -L` interop cases.

## Version

2024.2.0.4 → 2024.2.0.5.